### PR TITLE
Fix `com/ridanisaurus/emendatusenigmatica/datagen/base/GeneratedPack.java` to check Predicate on the results, instead of just ignoring it.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Enigmatica Discord
-    url: https://discord.gg/enigmatica
+  - name: EE Discord
+    url: https://discord.gg/HfVg3eJS2T
     about: The best place to receive quick answers to any questions you may have

--- a/patreon_supporters_list.json
+++ b/patreon_supporters_list.json
@@ -12,5 +12,6 @@
   "The_Boo": 2,
   "natebc": 2,
   "MuteTiefling": 2,
-  "LadyLexxie": 1
+  "LadyLexxie": 1,
+  "Kanzaji": 1
 }

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/datagen/base/GeneratedPack.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/datagen/base/GeneratedPack.java
@@ -40,7 +40,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class GeneratedPack implements PackResources {
@@ -105,12 +104,8 @@ public class GeneratedPack implements PackResources {
     @Override
     public Set<String> getNamespaces(PackType type) {
         Set<String> result = new HashSet<>();
-        try {
-            Stream<Path> list = Files.list(path.resolve(type.getDirectory()));
-            for (Path resultingPath : list.collect(Collectors.toList())) {
-                result.add(resultingPath.getFileName().toString());
-            }
-
+        try (Stream<Path> list = Files.list(path.resolve(type.getDirectory()))) {
+            for (Path resultingPath : list.toList()) result.add(resultingPath.getFileName().toString());
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -119,7 +114,7 @@ public class GeneratedPack implements PackResources {
 
     @Nullable
     @Override
-    public <T> T getMetadataSection(MetadataSectionSerializer<T> deserializer) throws IOException {
+    public <T> T getMetadataSection(MetadataSectionSerializer<T> deserializer) {
         JsonObject jsonobject = new JsonObject();
         JsonObject packObject = new JsonObject();
         packObject.addProperty("pack_format", 9);

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/datagen/base/GeneratedPack.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/datagen/base/GeneratedPack.java
@@ -78,20 +78,20 @@ public class GeneratedPack implements PackResources {
     }
 
     private void getChildResourceLocations(List<ResourceLocation> result, int depth, Predicate<ResourceLocation> filter, Path current, String currentRLNS, String currentRLPath) {
-        try {
-            if (!Files.exists(current) || !Files.isDirectory(current)){
-                return;
-            }
-            Stream<Path> list = Files.list(current);
-            for (Path child : list.collect(Collectors.toList())) {
+        if (!Files.exists(current) || !Files.isDirectory(current)){
+            return;
+        }
+        try (Stream<Path> list = Files.list(current)) {
+            for (Path child : list.toList()) {
                 if (!Files.isDirectory(child)) {
-                    result.add(new ResourceLocation(currentRLNS, currentRLPath + "/" + child.getFileName()));
-                    continue;
+                    ResourceLocation loc = new ResourceLocation(currentRLNS, currentRLPath + "/" + child.getFileName());
+                    if (filter.test(loc)) result.add(loc);
+                } else {
+                    getChildResourceLocations(result, depth + 1, filter, child, currentRLNS, currentRLPath + "/" + child.getFileName());
                 }
-                getChildResourceLocations(result, depth + 1, filter, child, currentRLNS, currentRLPath + "/" + child.getFileName());
             }
-        } catch (IOException ignored) {
-            ignored.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
Method `com/ridanisaurus/emendatusenigmatica/datagen/base/GeneratedPack.java#getChildResourceLocations` was rewritten, to be simpler, not cause potential Memory Leak due to Stream not being closed, and check provided Predicate before returning the results 😄

This didn't actually cause any issues with the mod itself, however it did cause bugs when some mod (Issue were caught with Apotheosis) tries to list Resources with use of Predicate, and EE resources were returned no matter the predicate, what in return caused just log spam, but in other mods might have caused nasty bugs / crashes.

Update: Additionally fix another unclosed Stream 😅