### PR TITLE
Add Validation for Data Json Files with feedback to the end user.

### DIFF
--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/EmendatusEnigmatica.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/EmendatusEnigmatica.java
@@ -25,7 +25,6 @@
 package com.ridanisaurus.emendatusenigmatica;
 
 import com.ridanisaurus.emendatusenigmatica.config.EEConfig;
-import com.ridanisaurus.emendatusenigmatica.core.mixin.OreVeinifierMixin;
 import com.ridanisaurus.emendatusenigmatica.datagen.base.DataGeneratorFactory;
 import com.ridanisaurus.emendatusenigmatica.datagen.base.EEPackFinder;
 import com.ridanisaurus.emendatusenigmatica.loader.EELoader;
@@ -71,6 +70,7 @@ public class EmendatusEnigmatica {
     public EmendatusEnigmatica() {
         EmendatusEnigmatica.instance = this;
         EEConfig.registerClient();
+        EEConfig.setupCommon();
 
         // Register Deferred Registers and populate their tables once the mod is done constructing
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/EmendatusEnigmatica.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/EmendatusEnigmatica.java
@@ -118,7 +118,7 @@ public class EmendatusEnigmatica {
             try {
                 if(generator == null)
                     registerDataGen();
-                    generator.run();
+                generator.run();
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/api/EmendatusDataRegistry.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/api/EmendatusDataRegistry.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.ridanisaurus.emendatusenigmatica.loader.parser.model.CompatModel;
 import com.ridanisaurus.emendatusenigmatica.loader.parser.model.MaterialModel;
 import com.ridanisaurus.emendatusenigmatica.loader.parser.model.StrataModel;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,8 +30,23 @@ public class EmendatusDataRegistry {
         this.strataByIndex = new HashMap<>();
     }
 
+    /**
+     * Used to register new Material model, returning passed defaultModel or previous value under that id.
+     * @param material ID of the material.
+     * @param defaultModel MaterialModel to register under that id.
+     * @return MaterialModel passed to the argument or previous MaterialModel that was registered under that id.
+     */
     public MaterialModel getMaterialOrRegister(String material, MaterialModel defaultModel){
         return this.materials.computeIfAbsent(material, s -> defaultModel);
+    }
+
+    /**
+     * Used to get MaterialModel by its ID.
+     * @param materialID MaterialID to get model of.
+     * @return MaterialModel under that ID, or null if not registered.
+     */
+    public @Nullable MaterialModel getMaterialByID(String materialID) {
+        return this.materials.get(materialID);
     }
 
     public void registerStrata(StrataModel strataModel){
@@ -55,6 +71,10 @@ public class EmendatusDataRegistry {
         return ImmutableList.copyOf(compat);
     }
 
+    /**
+     * Used to get Map with Strata Filler Types mapped to indexes of {@link EmendatusDataRegistry#strata} list.
+     * @return Map with mapping of Strata Filler Type -> Index of the model
+     */
     public Map<String, Integer> getStrataByIndex() {
         return strataByIndex;
     }

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/core/mixin/OreVeinifierMixin.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/core/mixin/OreVeinifierMixin.java
@@ -1,7 +1,8 @@
 package com.ridanisaurus.emendatusenigmatica.core.mixin;
 
+import com.ridanisaurus.emendatusenigmatica.EmendatusEnigmatica;
+import com.ridanisaurus.emendatusenigmatica.api.EmendatusDataRegistry;
 import com.ridanisaurus.emendatusenigmatica.loader.parser.model.MaterialModel;
-import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.Blocks;
@@ -12,6 +13,8 @@ import net.minecraft.world.level.levelgen.OreVeinifier;
 import net.minecraft.world.level.levelgen.PositionalRandomFactory;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+
+import java.util.Objects;
 
 @Mixin(OreVeinifier.class)
 public class OreVeinifierMixin {
@@ -48,16 +51,19 @@ public class OreVeinifierMixin {
                         if ((double)randomsource.nextFloat() < d3 && dFunction3.compute(filler) > (double)-0.3F) {
                             BlockState mixinRawOreBlock = oreveinifier$veintype.rawOreBlock;
                             BlockState mixinOreBlock = oreveinifier$veintype.ore;
-                            for (MaterialModel material : DefaultConfigPlugin.MATERIALS) {
-                                if (oreveinifier$veintype == OreVeinifier.VeinType.COPPER && material.getId().equals("copper") && material.getDisableDefaultOre()) {
-                                    mixinRawOreBlock = Blocks.STONE.defaultBlockState();
-                                    mixinOreBlock = Blocks.STONE.defaultBlockState();
-                                }
-                                if (oreveinifier$veintype == OreVeinifier.VeinType.IRON && material.getId().equals("iron") && material.getDisableDefaultOre()) {
-                                    mixinRawOreBlock = Blocks.DEEPSLATE.defaultBlockState();
-                                    mixinOreBlock = Blocks.DEEPSLATE.defaultBlockState();
-                                }
+
+                            EmendatusDataRegistry registry = EmendatusEnigmatica.getInstance().getLoader().getDataRegistry();
+                            MaterialModel copper = registry.getMaterialByID("copper");
+                            MaterialModel iron = registry.getMaterialByID("iron");
+
+                            if (oreveinifier$veintype == OreVeinifier.VeinType.COPPER && Objects.nonNull(copper) && copper.getDisableDefaultOre()) {
+                                mixinRawOreBlock = Blocks.STONE.defaultBlockState();
+                                mixinOreBlock = Blocks.STONE.defaultBlockState();
+                            } else if (oreveinifier$veintype == OreVeinifier.VeinType.IRON && Objects.nonNull(iron) && iron.getDisableDefaultOre()) {
+                                mixinRawOreBlock = Blocks.DEEPSLATE.defaultBlockState();
+                                mixinOreBlock = Blocks.DEEPSLATE.defaultBlockState();
                             }
+
                             return randomsource.nextFloat() < 0.02F ? mixinRawOreBlock : mixinOreBlock;
                         } else {
                             return oreveinifier$veintype.filler;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/datagen/RecipesGen.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/datagen/RecipesGen.java
@@ -24,11 +24,7 @@
 
 package com.ridanisaurus.emendatusenigmatica.datagen;
 
-import com.google.common.base.Suppliers;
-import com.google.common.collect.BiMap;
-import com.google.common.collect.ImmutableBiMap;
 import com.ridanisaurus.emendatusenigmatica.api.EmendatusDataRegistry;
-import com.ridanisaurus.emendatusenigmatica.blocks.BasicWaxedBlock;
 import com.ridanisaurus.emendatusenigmatica.loader.parser.model.MaterialModel;
 import com.ridanisaurus.emendatusenigmatica.registries.EERegistrar;
 import com.ridanisaurus.emendatusenigmatica.registries.EETags;
@@ -37,20 +33,16 @@ import net.minecraft.advancements.critereon.InventoryChangeTrigger;
 import net.minecraft.data.*;
 import net.minecraft.data.recipes.*;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.HoneycombItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.common.Tags;
-import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 public class RecipesGen extends RecipeProvider {
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/EELoader.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/EELoader.java
@@ -38,11 +38,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class EELoader {
-
     public static final Logger LOADER_LOGGER = LogManager.getLogger(EELoader.class);
     private final EmendatusDataRegistry dataRegistry;
-
-    private List<IEmendatusPlugin> plugins;
+    private final List<IEmendatusPlugin> plugins;
 
 public EELoader() {
         this.dataRegistry = new EmendatusDataRegistry();

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/Validator.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/Validator.java
@@ -108,17 +108,17 @@ public class Validator {
             try {
                 if (element.isJsonObject()) throw new ClassCastException();
                 boolean value = element.getAsString().isBlank();
-                if (value && log) LOGGER.error("\"%s\" in file \"%s\" can't be blank!".formatted(name, obfuscatePath(path)));
+                if (value) LOGGER.error("\"%s\" in file \"%s\" can't be blank!".formatted(name, obfuscatePath(path)));
                 return !value;
             } catch (ClassCastException e) {
-                if (log) LOGGER.error("\"%s\" in file \"%s\" requires String value!".formatted(name, obfuscatePath(path)));
+                LOGGER.error("\"%s\" in file \"%s\" requires String value!".formatted(name, obfuscatePath(path)));
             }
             return false;
         });
 
         REQUIRED = (data, jsonPath) -> {
             boolean value = Objects.nonNull(data);
-            if (!value && log) LOGGER.error("\"%s\" in file \"%s\" is missing!".formatted(name, obfuscatePath(jsonPath)));
+            if (!value) LOGGER.error("\"%s\" in file \"%s\" is missing!".formatted(name, obfuscatePath(jsonPath)));
             return value;
         };
 
@@ -131,7 +131,7 @@ public class Validator {
                 data.getAsBoolean();
                 return true;
             } catch (ClassCastException e) {
-                if (log) LOGGER.error("\"%s\" in file \"%s\" requires Boolean (true/false) value!".formatted(name, obfuscatePath(jsonPath)));
+                LOGGER.error("\"%s\" in file \"%s\" requires Boolean (true/false) value!".formatted(name, obfuscatePath(jsonPath)));
             }
             return false;
         };
@@ -148,7 +148,7 @@ public class Validator {
                 }
                 return true;
             } catch (ClassCastException | NumberFormatException e) {
-                if (log) LOGGER.error("\"%s\" in file \"%s\" requires numeric value!".formatted(name, obfuscatePath(jsonPath)));
+                LOGGER.error("\"%s\" in file \"%s\" requires numeric value!".formatted(name, obfuscatePath(jsonPath)));
             }
             return false;
         };
@@ -162,7 +162,7 @@ public class Validator {
                 data.getAsDouble();
                 return true;
             } catch (ClassCastException | NumberFormatException e) {
-                if (log) LOGGER.error("\"%s\" in file \"%s\" requires numeric value!".formatted(name, obfuscatePath(jsonPath)));
+                LOGGER.error("\"%s\" in file \"%s\" requires numeric value!".formatted(name, obfuscatePath(jsonPath)));
             }
             return false;
         };
@@ -177,15 +177,15 @@ public class Validator {
             String[] values = (value + " :").split(":");
             boolean validation = true;
             if (values.length != 2) {
-                if (log) LOGGER.error("Provided Resource ID in \"%s\" in file \"%s\" isn't in a proper format! Expected: \"namespace:id\", got: \"%s\".".formatted(name, obfuscatePath(path), value));
+                LOGGER.error("Provided Resource ID in \"%s\" in file \"%s\" isn't in a proper format! Expected: \"namespace:id\", got: \"%s\".".formatted(name, obfuscatePath(path), value));
                 return false;
             }
             if (values[0].isBlank()) {
-                if (log) LOGGER.error("Provided Resource ID in \"%s\" in file \"%s\" is missing the namespace! Expected: \"namespace:id\", got: \"%s\".".formatted(name, obfuscatePath(path), value));
+                LOGGER.error("Provided Resource ID in \"%s\" in file \"%s\" is missing the namespace! Expected: \"namespace:id\", got: \"%s\".".formatted(name, obfuscatePath(path), value));
                 validation = false;
             }
             if (values[1].isBlank()) {
-                if (log) LOGGER.error("Provided Resource ID in \"%s\" in file \"%s\" is missing the id! Expected: \"namespace:id\", got: \"%s\".".formatted(name, obfuscatePath(path), value));
+                LOGGER.error("Provided Resource ID in \"%s\" in file \"%s\" is missing the id! Expected: \"namespace:id\", got: \"%s\".".formatted(name, obfuscatePath(path), value));
                 validation = false;
             }
             return validation;
@@ -201,26 +201,22 @@ public class Validator {
             boolean validation = true;
 
             if (value.startsWith("#")) {
-                if (log) LOGGER.error("Hexadecimal color values should not start with #! Found in \"%s\" in file \"%s\"".formatted(name, obfuscatePath(path)));
+                LOGGER.error("Hexadecimal color values should not start with #! Found in \"%s\" in file \"%s\"".formatted(name, obfuscatePath(path)));
                 value = value.substring(1);
                 validation = false;
             }
             if (value.length() != 6) {
-                if (log) {
-                    LOGGER.error("Too %s hexadecimal value for color in \"%s\" in file \"%s\"! String should have length 6 (RR GG BB (Red / Green / Blue value)), but it has %d."
-                        .formatted(value.length() > 6? "long": "short", name, obfuscatePath(path), value.length())
-                    );
-                }
+                LOGGER.error("Too %s hexadecimal value for color in \"%s\" in file \"%s\"! String should have length 6 (RR GG BB (Red / Green / Blue value)), but it has %d."
+                    .formatted(value.length() > 6? "long": "short", name, obfuscatePath(path), value.length())
+                );
                 validation = false;
             } else {
                 try {
                     HexFormat.fromHexDigits(value);
                 } catch (Exception e) {
-                    if (log) {
-                        LOGGER.error("Non-Hexadecimal character found in provided string (\"%s\") in \"%s\" in file \"%s\".".
-                            formatted(value, name, obfuscatePath(path))
-                        );
-                    }
+                    LOGGER.error("Non-Hexadecimal character found in provided string (\"%s\") in \"%s\" in file \"%s\".".
+                        formatted(value, name, obfuscatePath(path))
+                    );
                     validation = false;
                 }
             }
@@ -243,13 +239,13 @@ public class Validator {
                 if (!element.isJsonPrimitive()) throw new ClassCastException();
                 double value = element.getAsDouble();
                 if (value < min || value > max) {
-                    if (log) LOGGER.error("\"%s\" in file \"%s\" is out of range! Provided: %f, Min: %f, Max: %f.".formatted(name, obfuscatePath(path), value, min, max));
+                    LOGGER.error("\"%s\" in file \"%s\" is out of range! Provided: %f, Min: %f, Max: %f.".formatted(name, obfuscatePath(path), value, min, max));
                     return false;
                 }
                 return true;
             } catch (Exception e) {
                 if (Objects.isNull(element)) return true;
-                if (log) LOGGER.error("\"%s\" in file \"%s\" requires a numeric value!".formatted(name, obfuscatePath(path)));
+                LOGGER.error("\"%s\" in file \"%s\" requires a numeric value!".formatted(name, obfuscatePath(path)));
             }
             return false;
         });
@@ -304,13 +300,13 @@ public class Validator {
 
                 long value = element.getAsLong();
                 if (value < min || value > max) {
-                    if (log) LOGGER.error("\"%s\" in file \"%s\" is out of range! Provided: %d, Min: %d, Max: %d.".formatted(name, obfuscatePath(path), value, min, max));
+                    LOGGER.error("\"%s\" in file \"%s\" is out of range! Provided: %d, Min: %d, Max: %d.".formatted(name, obfuscatePath(path), value, min, max));
                     return false;
                 }
                 return true;
             } catch (ClassCastException | NullPointerException e) {
                 if (Objects.isNull(element)) return true;
-                if (log) LOGGER.error("\"%s\" in file \"%s\" requires a numeric value!".formatted(name, obfuscatePath(path)));
+                LOGGER.error("\"%s\" in file \"%s\" requires a numeric value!".formatted(name, obfuscatePath(path)));
             }
             return false;
         });
@@ -371,6 +367,56 @@ public class Validator {
     }
 
     /**
+     * Used to get a validator that checks if value is not one of the illegal ones. Supports: String
+     * @param values List with illegal String values.
+     * @return BiFunction used as validator.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getIllegalValuesValidation(List<String> values) {
+        return (data, jsonPath) -> validateArray(data, jsonPath, (element, path) -> {
+            if (Objects.isNull(element)) return true;
+            try {
+                if (!element.isJsonPrimitive()) throw new ClassCastException();
+                String value = element.getAsString();
+                boolean validation = values.contains(value);
+                if (validation) LOGGER.error("\"%s\" in file \"%s\" contains illegal value (%s)! Illegal values are: %s".formatted(name, obfuscatePath(path), value, String.join(", ", values)));
+                return !validation;
+            } catch (ClassCastException e) {
+                LOGGER.error("\"%s\" in file \"%s\" requires String value!".formatted(name, obfuscatePath(path)));
+            }
+            return false;
+        });
+    }
+
+    /**
+     * Used to get a validator that checks if value is not one of the illegal ones. Supports: String
+     * @param values List with illegal String values.
+     * @param array Determines if expected is an array value (true) or not (false);
+     * @return BiFunction used as validator.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getIllegalValuesValidation(List<String> values, boolean array) {
+        return (jsonElement, path) -> (array? assertArray(jsonElement, path): assertNotArray(jsonElement, path)) && getIllegalValuesValidation(values).apply(jsonElement, path);
+    }
+
+    /**
+     * Used to get a validator that checks if value is not one of the illegal ones. Supports: String
+     * @param values List with illegal String values.
+     * @return BiFunction used as validator.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getRequiredIllegalValuesValidation(List<String> values) {
+        return (element, path) -> REQUIRED.apply(element, path) && getIllegalValuesValidation(values).apply(element, path);
+    }
+
+    /**
+     * Used to get a validator that checks if value is not one of the illegal ones. Supports: String
+     * @param values List with illegal String values.
+     * @param array Determines if expected is an array value (true) or not (false);
+     * @return BiFunction used as validator.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getRequiredIllegalValuesValidation(List<String> values, boolean array) {
+        return (element, path) -> REQUIRED.apply(element, path) && getIllegalValuesValidation(values, array).apply(element, path);
+    }
+
+    /**
      * Used to get a validator that checks if value is one of the acceptable ones. Supports: String
      * @param values List with accepted String values.
      * @return BiFunction used as validator.
@@ -382,10 +428,10 @@ public class Validator {
                 if (!element.isJsonPrimitive()) throw new ClassCastException();
                 String value = element.getAsString();
                 boolean validation = values.contains(value);
-                if (log && !validation) LOGGER.error("\"%s\" in file \"%s\" contains illegal value (%s)! Accepted values are: %s".formatted(name, obfuscatePath(path), value, String.join(", ", values)));
+                if (!validation) LOGGER.error("\"%s\" in file \"%s\" contains illegal value (%s)! Accepted values are: %s".formatted(name, obfuscatePath(path), value, String.join(", ", values)));
                 return validation;
             } catch (ClassCastException e) {
-                if (log) LOGGER.error("\"%s\" in file \"%s\" requires String value!".formatted(name, obfuscatePath(path)));
+                LOGGER.error("\"%s\" in file \"%s\" requires String value!".formatted(name, obfuscatePath(path)));
             }
             return false;
         });
@@ -394,6 +440,7 @@ public class Validator {
     /**
      * Used to get a validator that checks if value is one of the acceptable ones. Supports: String
      * @param values List with accepted String values.
+     * @param array Determines if expected is an array value (true) or not (false);
      * @return BiFunction used as validator.
      */
     public BiFunction<JsonElement, Path, Boolean> getAcceptsOnlyValidation(List<String> values, boolean array) {
@@ -412,6 +459,7 @@ public class Validator {
     /**
      * Used to get a validator that checks if value is one of the acceptable ones, marked as Required. Supports: String
      * @param values List with accepted String values.
+     * @param array Determines if expected is an array value (true) or not (false);
      * @return BiFunction used as validator.
      */
     public BiFunction<JsonElement, Path, Boolean> getRequiredAcceptsOnlyValidation(List<String> values, boolean array) {
@@ -428,7 +476,7 @@ public class Validator {
         return (element, path) -> {
             if (Objects.isNull(element)) return true;
             if (!element.isJsonArray()) {
-                if (log) LOGGER.error("Expected array for \"%s\" in file \"%s\".".formatted(name, obfuscatePath(path)));
+                LOGGER.error("Expected array for \"%s\" in file \"%s\".".formatted(name, obfuscatePath(path)));
                 return false;
             }
 
@@ -448,7 +496,7 @@ public class Validator {
 
             pairs.forEach(pair -> {
                 if (values.contains(pair.getFirst()) && values.contains(pair.getSecond())) {
-                    if (log) LOGGER.error("Illegal pair found (%s and %s) in the array \"%s\" of file \"%s\".".formatted(pair.getFirst(), pair.getSecond(), name, obfuscatePath(path)));
+                    LOGGER.error("Illegal pair found (%s and %s) in the array \"%s\" of file \"%s\".".formatted(pair.getFirst(), pair.getSecond(), name, obfuscatePath(path)));
                     validation.set(false);
                 }
             });
@@ -494,7 +542,7 @@ public class Validator {
     public boolean passTempToValidators(JsonObject tempObject, @Nullable JsonElement element, Path path, Map<String, BiFunction<JsonElement, Path, Boolean>> validators, boolean required) {
         if (Objects.isNull(element)) return (required? REQUIRED.apply(null, path): true);
         if (element.isJsonPrimitive() || element.isJsonNull()) {
-            if (log) LOGGER.error("Expected array or object for \"%s\" in file \"%s\".".formatted(name, obfuscatePath(path)));
+            LOGGER.error("Expected array or object for \"%s\" in file \"%s\".".formatted(name, obfuscatePath(path)));
             return false;
         }
 
@@ -533,7 +581,7 @@ public class Validator {
     public boolean checkForTEMP(JsonObject object, Path path, boolean shouldLog) {
         JsonElement tempElement = object.get("TEMP");
         boolean temp = Objects.nonNull(tempElement);
-        if (temp && log && shouldLog) LOGGER.warn("Unknown key (\"TEMP\") found in file \"%s\".".formatted(obfuscatePath(path)));
+        if (temp && shouldLog) LOGGER.warn("Unknown key (\"TEMP\") found in file \"%s\".".formatted(obfuscatePath(path)));
         return temp && tempElement.isJsonObject();
     }
 
@@ -569,8 +617,8 @@ public class Validator {
             JsonObject object = element.getAsJsonObject();
             AtomicBoolean validation = new AtomicBoolean(true);
 
-            object.entrySet().forEach(entry -> {
-                if (log && !(validators.containsKey(entry.getKey()) || validators.containsKey(entry.getKey() + "_rg"))) {
+            if (log) object.entrySet().forEach(entry -> {
+                if (!(validators.containsKey(entry.getKey()) || validators.containsKey(entry.getKey() + "_rg"))) {
                     LOGGER.warn("Unknown key (\"%s\") found in file \"%s\".".formatted(entry.getKey(), obfuscatePath(jsonPath)));
                 }
             });
@@ -590,7 +638,7 @@ public class Validator {
      */
     public boolean assertObject(@Nullable JsonElement element, Path path) {
         if (Objects.isNull(element) || !element.isJsonObject()) {
-            if (log) LOGGER.error("Expected object for verification of key \"%s\" in file \"%s\"%s".formatted(name, obfuscatePath(path), Objects.isNull(element)? ", got null.": "."));
+            LOGGER.error("Expected object for verification of key \"%s\" in file \"%s\"%s".formatted(name, obfuscatePath(path), Objects.isNull(element)? ", got null.": "."));
             return false;
         }
         return true;
@@ -598,7 +646,7 @@ public class Validator {
 
     public boolean assertParentObject(@Nullable JsonElement element, Path path) {
         if (Objects.isNull(element) || !element.isJsonObject()) {
-            if (log) LOGGER.error("Expected parent object for verification of key \"%s\" in file \"%s\"%s".formatted(name, obfuscatePath(path), Objects.isNull(element)? ", got null.": "."));
+            LOGGER.error("Expected parent object for verification of key \"%s\" in file \"%s\"%s".formatted(name, obfuscatePath(path), Objects.isNull(element)? ", got null.": "."));
             return false;
         }
         return true;
@@ -612,7 +660,7 @@ public class Validator {
      */
     public boolean assertNotArray(@Nullable JsonElement element, Path path) {
         if (Objects.nonNull(element) && element.isJsonArray()) {
-            if (log) LOGGER.error("Array found on non-array key \"%s\" in file \"%s\".".formatted(name, obfuscatePath(path)));
+            LOGGER.error("Array found on non-array key \"%s\" in file \"%s\".".formatted(name, obfuscatePath(path)));
             return false;
         }
         return true;
@@ -626,7 +674,7 @@ public class Validator {
      */
     public boolean assertArray(@Nullable JsonElement element, Path path) {
         if (Objects.isNull(element) || !element.isJsonArray()) {
-            if (log) LOGGER.error("Expected array for verification of key \"%s\" in file \"%s\"%s".formatted(name, obfuscatePath(path), Objects.isNull(element)? ", got null.": "."));
+            LOGGER.error("Expected array for verification of key \"%s\" in file \"%s\"%s".formatted(name, obfuscatePath(path), Objects.isNull(element)? ", got null.": "."));
             return false;
         }
         return true;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/Validator.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/Validator.java
@@ -1,0 +1,322 @@
+package com.ridanisaurus.emendatusenigmatica.loader;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.datafixers.util.Pair;
+import com.ridanisaurus.emendatusenigmatica.config.EEConfig;
+import net.minecraftforge.fml.loading.FMLPaths;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+
+/**
+ * This class holds default validators for values from json configuration files.
+ * @apiNote If not specified, the validator supports JsonArrays.
+ */
+public class Validator {
+    //TODO: Validation of:
+    // - Strata - DONE
+    // - Compat Model - DONE
+    // - Material Model - DONE
+    // - All of the Material sub-models (pain)
+    // - Deposits
+    public static final boolean log = EEConfig.common.logConfigErrors.get();
+    public static final Logger LOGGER = LoggerFactory.getLogger("EE Data Validation");
+    /**
+     * All values are accepted. Simply returns true.
+     */
+    public static final BiFunction<JsonElement, Path, Boolean> ALL = (data, path) -> true;
+    /**
+     * Value is required (can't be null).
+     * @apiNote This only checks if provided JsonElement <i>is not null</i>! It doesn't check if an array is empty or not.
+     */
+    public final BiFunction<JsonElement, Path, Boolean> REQUIRED;
+    /**
+     * String has to be filled with something, but it's not required (can be null).
+     * @apiNote Returns false if value is not String.
+     */
+    public final BiFunction<JsonElement, Path, Boolean> NON_EMPTY;
+    /**
+     * String has to be filled with something and is required (can't be null).
+     */
+    public final BiFunction<JsonElement, Path, Boolean> NON_EMPTY_REQUIRED;
+    /**
+     * ResourceLocation has to exist, but is not required (can be null).
+     */
+    public final BiFunction<JsonElement, Path, Boolean> RESOURCE_EXISTS;
+    /**
+     * ResourceLocation has to exist and is required (can't be null).
+     */
+    public final BiFunction<JsonElement, Path, Boolean> RESOURCE_EXISTS_REQUIRED;
+    private final String name;
+
+    public Validator(String fieldName) {
+        name = fieldName;
+
+        NON_EMPTY = (data, jsonPath) -> validateArray(data, jsonPath, (element, path) -> {
+            try {
+                if (Objects.isNull(element)) return true;
+                boolean value = element.getAsString().isBlank();
+                if (value && log) LOGGER.error("%s in file \"%s\" can't be blank!".formatted(name, obfuscatePath(path)));
+                return !value;
+            } catch (Exception e) {
+                if (log) LOGGER.error("%s in file \"%s\" requires String value!".formatted(name, obfuscatePath(path)));
+            }
+            return false;
+        });
+
+        REQUIRED = (data, jsonPath) -> {
+            boolean value = Objects.nonNull(data);
+            if (!value && log) LOGGER.error("%s in file \"%s\" is missing!".formatted(name, obfuscatePath(jsonPath)));
+            return value;
+        };
+
+        NON_EMPTY_REQUIRED = (data, jsonPath) -> REQUIRED.apply(data, jsonPath) && NON_EMPTY.apply(data, jsonPath);
+
+        // It's very likely I can't verify this.
+        RESOURCE_EXISTS = (data, jsonPath) -> true;
+
+        RESOURCE_EXISTS_REQUIRED = (data, jsonPath) -> REQUIRED.apply(data, jsonPath) && RESOURCE_EXISTS.apply(data, jsonPath);
+    }
+
+    /**
+     * Used to get validator of Number Range. Supports: int, long, float, double.
+     * @param min Minimum value.
+     * @param max Maximum value.
+     * @return BiFunction used as validator.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getRange(double min, double max) {
+        return (data, jsonPath) -> validateArray(data, jsonPath, (element, path) -> {
+            try {
+                double value = element.getAsDouble();
+                if (value < min || value > max) {
+                    if (log) LOGGER.error("%s in file \"%s\" is out of range! Provided: %f, Min: %f, Max: %f.".formatted(name, obfuscatePath(path), value, min, max));
+                    return false;
+                }
+                return true;
+            } catch (Exception e) {
+                if (Objects.isNull(element)) return true;
+                if (log) LOGGER.error("%s in file \"%s\" requires a numeric value!".formatted(name, obfuscatePath(path)));
+            }
+            return false;
+        });
+    }
+
+    /**
+     * Used to get validator of Number Range. Supports: int, long, float, double.
+     * @param min Minimum value.
+     * @param max Maximum value.
+     * @return BiFunction used as validator.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getRequiredRange(double min, double max) {
+        return (data, jsonPath) -> REQUIRED.apply(data, jsonPath) && getRange(min, max).apply(data, jsonPath);
+    }
+
+    /**
+     * Used to get validator of another JsonObject.
+     * @param validators Map with validators for JsonObject to verify.
+     * @return BiFunction used as validator.
+     * @apiNote This is a wrapper of {@link Validator#validateObject(JsonElement, Path, Map)}. See JavaDoc for that method for full documentation.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getObjectValidation(Map<String, BiFunction<JsonElement, Path, Boolean>> validators) {
+        return (element, path) -> validateObject(element, path, validators);
+    }
+
+    /**
+     * Used to get validator of another JsonObject marked as REQUIRED.
+     * @param validators Map with validators for JsonObject to verify.
+     * @return BiFunction used as validator.
+     * @apiNote This is a wrapper of {@link Validator#validateObject(JsonElement, Path, Map)}. See JavaDoc for that method for full documentation.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getRequiredObjectValidation(Map<String, BiFunction<JsonElement, Path, Boolean>> validators) {
+        return (element, path) -> REQUIRED.apply(element, path) && validateObject(element, path, validators);
+    }
+
+    /**
+     * Used to get a validator that checks if value is one of the acceptable ones. Supports: String
+     * @param values List with accepted String values.
+     * @return BiFunction used as validator.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getAcceptsOnlyValidation(List<String> values) {
+        return (data, jsonPath) -> validateArray(data, jsonPath, (element, path) -> {
+            if (Objects.isNull(element)) return true;
+            try {
+                String value = element.getAsString();
+                boolean validation = values.contains(value);
+                if (log && !validation) LOGGER.error("%s in file \"%s\" contains illegal value (%s)! Accepted values are: %s".formatted(name, obfuscatePath(path), value, String.join(", ", values)));
+                return validation;
+            } catch (Exception e) {
+                if (log) LOGGER.error("%s in file \"%s\" requires String value!".formatted(name, obfuscatePath(path)));
+            }
+            return false;
+        });
+    }
+
+    /**
+     * Used to get a validator that checks if value is one of the acceptable ones, marked as Required. Supports: String
+     * @param values List with accepted String values.
+     * @return BiFunction used as validator.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getRequiredAcceptsOnlyValidation(List<String> values) {
+        return (element, path) -> REQUIRED.apply(element, path) && getAcceptsOnlyValidation(values).apply(element, path);
+    }
+
+    /**
+     * Used to get a validator that checks the array for containing illegal pairs of values. Supports: String
+     * @param pairs List of Pairs with values that are illegal at the same time.
+     * @return BiFunction used as validator.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getIllegalPairsValidation(List<Pair<String, String>> pairs) {
+        return (element, path) -> {
+            if (Objects.isNull(element)) return true;
+            if (!element.isJsonArray()) {
+                if (log) LOGGER.error("Expected array for %s in file \"%s\".".formatted(name, obfuscatePath(path)));
+                return false;
+            }
+
+            List<String> values = new ArrayList<>();
+            AtomicBoolean validation = new AtomicBoolean(true);
+
+            element.getAsJsonArray().forEach(entry -> {
+                try {
+                    values.add(entry.getAsString());
+                } catch (Exception e) {
+                    LOGGER.error("Non-String value present in the array of %s in file \"%s\".".formatted(name, obfuscatePath(path)));
+                    validation.set(false);
+                }
+            });
+
+            if (values.size() <= 1 && !validation.get()) return false;
+
+            pairs.forEach(pair -> {
+                if (values.contains(pair.getFirst()) && values.contains(pair.getSecond())) {
+                    if (log) LOGGER.error("Illegal pair found (%s and %s) in the array %s of file \"%s\".".formatted(pair.getFirst(), pair.getSecond(), name, obfuscatePath(path)));
+                    validation.set(false);
+                }
+            });
+
+            return validation.get();
+        };
+    }
+
+    /**
+     * Used to get a validator that checks the array for containing illegal pairs of values, marked as Required. Supports: String
+     * @param pairs List of Pairs with values that are illegal at the same time.
+     * @return BiFunction used as validator.
+     * @apiNote This uses NON_EMPTY_REQUIRED instead of REQUIRED, so if you want to allow empty string, use {@link Validator#getIllegalPairsValidation(List)} instead.
+     */
+    public BiFunction<JsonElement, Path, Boolean> getRequiredIllegalPairsValidation(List<Pair<String,String>> pairs) {
+        return (element, path) -> NON_EMPTY_REQUIRED.apply(element, path) && getIllegalPairsValidation(pairs).apply(element, path);
+    }
+
+    /**
+     * Used to validate a JsonArray with provided validator (BiFunction).
+     * @param element JsonElement to verify. If not Array, it will verify just that element.
+     * @param path Path of the json, only for informational purposes.
+     * @param validator BiFunction used as a Validator.
+     * @return true if all entries in the array pass validation, otherwise false. In case JsonElement is not an array, returns result of the validation.
+     */
+    public boolean validateArray(@Nullable JsonElement element, Path path, BiFunction<JsonElement, Path, Boolean> validator) {
+        if (Objects.nonNull(element) && element.isJsonArray()) {
+            AtomicBoolean validation = new AtomicBoolean(true);
+            element.getAsJsonArray().forEach(entry -> {if (!validateArray(entry, path, validator)) validation.set(false);});
+            return validation.get();
+        }
+        return validator.apply(element, path);
+    }
+
+    /**
+     * Used to validate another JsonObject with provided validators for that object.
+     * @param jsonElement Object to verify.
+     * @param path Path to the file, only for informational purposes.
+     * @param validators Map with validators for passed JsonObject.
+     * @return True if validations pass, False if validations fail or jsonElement is not a JsonObject.
+     * @apiNote Be aware that this might break if used in chained _rg requests. If you need to chain _rg requests to get parent of the object, you need to do your own implementation.
+     */
+    public boolean validateObject(JsonElement jsonElement, Path path, Map<String, BiFunction<JsonElement, Path, Boolean>> validators) {
+        return validateArray(jsonElement, path, (element, jsonPath) -> {
+            if (Objects.isNull(element)) return true;
+            if (!element.isJsonObject()) {
+                if (log) LOGGER.error("Expected object for key %s in %s.".formatted(name, obfuscatePath(jsonPath)));
+                return false;
+            }
+
+            JsonObject object = element.getAsJsonObject();
+            AtomicBoolean validation = new AtomicBoolean(true);
+
+            object.entrySet().forEach(entry -> {
+                if (log && !(validators.containsKey(entry.getKey()) || validators.containsKey(entry.getKey() + "_rg"))) {
+                    LOGGER.warn("Unknown key (%s) found in file \"%s\".".formatted(entry.getKey(), obfuscatePath(jsonPath)));
+                }
+            });
+
+            validators.forEach((field, validator) -> {
+                if (!validator.apply(field.endsWith("_rg")? object: object.get(field), jsonPath)) validation.set(false);
+            });
+            return validation.get();
+        });
+    }
+
+    /**
+     * Utility method used for custom validators while using _rg suffix. Checks if parent JsonElement is JsonObject.
+     * @param element JsonElement to check. Nullable.
+     * @param path Path of the file.
+     * @return True if JsonObject, otherwise false.
+     */
+    public boolean assertObject(@Nullable JsonElement element, Path path) {
+        if (Objects.isNull(element) || !element.isJsonObject()) {
+            if (log) LOGGER.error("Expected object for verification of key %s in file \"%s\"%s Something is terribly wrong.".formatted(name, obfuscatePath(path), Objects.isNull(element)? ", got null.": "."));
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Utility method used for custom validators for fields that should not be arrays.
+     * @param element JsonElement to check. Nullable.
+     * @param path Path of the file.
+     * @return False if JsonArray, otherwise true.
+     */
+    public boolean assertNotArray(@Nullable JsonElement element, Path path) {
+        if (Objects.nonNull(element) && element.isJsonArray()) {
+            if (log) LOGGER.error("Array found on non-array key %s in file \"%s\".".formatted(name, obfuscatePath(path)));
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Utility method used for custom validators for fields that should be arrays.
+     * @param element JsonElement to check. Nullable.
+     * @param path Path of the file.
+     * @return True if JsonArray, otherwise false.
+     */
+    public boolean assertArray(@Nullable JsonElement element, Path path) {
+        if (Objects.isNull(element) || !element.isJsonArray()) {
+            if (log) LOGGER.error("Expected array for verification of key %s in file \"%s\"%s".formatted(name, obfuscatePath(path), Objects.isNull(element)? ", got null.": "."));
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Used to cut off part of the path that is not in minecraft directory.<br><br>
+     * Input: <br>
+     * {@code C:/Minecraft/config/emendatusenigmatica/strata/stone.json}<br>
+     * Result: <br>
+     * {@code strata/stone.json}
+     * @param path Path to obfuscate.
+     * @return String with an obfuscated path.
+     */
+    public static String obfuscatePath(Path path) {
+        return FMLPaths.CONFIGDIR.get().resolve("emendatusenigmatica/").relativize(path).toString();
+    }
+}

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/Validator.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/Validator.java
@@ -23,8 +23,9 @@ public class Validator {
     // - Strata - DONE
     // - Compat Model - DONE
     // - Material Model - DONE
-    // - All of the Material sub-models (pain)
+    // - All of the Material sub-models (pain) - DONE
     // - Deposits
+    // - Code Cleanup
     public static final boolean log = EEConfig.common.logConfigErrors.get();
     public static final ValidatorLogger LOGGER = new ValidatorLogger(LoggerFactory.getLogger("EE Data Validation"));
     /**

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/Validator.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/Validator.java
@@ -259,7 +259,8 @@ public class Validator {
      * @return BiFunction used as validator.
      */
     public BiFunction<JsonElement, Path, Boolean> getRange(double min, double max, boolean array) {
-        return (jsonElement, path) -> (array? assertArray(jsonElement, path): assertNotArray(jsonElement, path)) && getRange(min, max).apply(jsonElement, path);
+        return (jsonElement, path) ->
+            Objects.isNull(jsonElement) || (array? assertArray(jsonElement, path): assertNotArray(jsonElement, path)) && getRange(min, max).apply(jsonElement, path);
     }
 
     /**
@@ -320,7 +321,8 @@ public class Validator {
      * @return BiFunction used as validator.
      */
     public BiFunction<JsonElement, Path, Boolean> getIntRange(long min, long max, boolean array) {
-        return (jsonElement, path) -> (array? assertArray(jsonElement, path): assertNotArray(jsonElement, path)) && getIntRange(min, max).apply(jsonElement, path);
+        return (jsonElement, path) ->
+            Objects.isNull(jsonElement) || (array? assertArray(jsonElement, path): assertNotArray(jsonElement, path)) && getIntRange(min, max).apply(jsonElement, path);
     }
 
     /**
@@ -371,10 +373,11 @@ public class Validator {
      * to check if ID isn't already registered in the provided registry.
      * @param values List with IDS to check against.
      * @return BiFunction used as validator.
+     * @apiNote Take a note this implements "NON_EMPTY_REQUIRED" and assertNotArray validations.
      */
     public BiFunction<JsonElement, Path, Boolean> getIDValidation(List<String> values) {
         return (element, path) -> {
-            if (!assertNotArray(element, path) && !NON_EMPTY_REQUIRED.apply(element, path)) return false;
+            if (!assertNotArray(element, path) || !NON_EMPTY_REQUIRED.apply(element, path)) return false;
             String value = element.getAsString();
             boolean isIllegal = values.contains(value);
             if (isIllegal) LOGGER.error("\"%s\" (%s) found in file \"%s\" is already registered!".formatted(name, value, obfuscatePath(path)));
@@ -412,7 +415,36 @@ public class Validator {
      * {@code "FIELD_NAME" (VALUE) found in file "PATH" isn't registered in "registryType"!}
      */
     public BiFunction<JsonElement, Path, Boolean> getRegisteredIDValidation(List<String> values, String registryType, boolean array) {
-        return (element, path) -> (array? assertArray(element, path): assertNotArray(element, path)) && getRegisteredIDValidation(values, registryType).apply(element, path);
+        return (element, path) ->
+            Objects.isNull(element) || (array? assertArray(element, path): assertNotArray(element, path)) && getRegisteredIDValidation(values, registryType).apply(element, path);
+    }
+
+    /**
+     * Custom version of {@link Validator#getRequiredAcceptsOnlyValidation(List)} that is used
+     * to check if ID is registered in the provided registry. Marked as Required.
+     * @param values List with IDS to check against.
+     * @param registryType String with a registry type. Used only for logging.
+     * @param array Determines if expected is an array value (true) or not (false);
+     * @return BiFunction used as validator.
+     * @apiNote Log entry template:<br>
+     * {@code "FIELD_NAME" (VALUE) found in file "PATH" isn't registered in "registryType"!}
+     */
+    public BiFunction<JsonElement, Path, Boolean> getRequiredRegisteredIDValidation(List<String> values, String registryType) {
+        return (element, path) -> REQUIRED.apply(element, path) && getRegisteredIDValidation(values, registryType).apply(element, path);
+    }
+
+    /**
+     * Custom version of {@link Validator#getRequiredAcceptsOnlyValidation(List)} that is used
+     * to check if ID is registered in the provided registry. Marked as Required.
+     * @param values List with IDS to check against.
+     * @param registryType String with a registry type. Used only for logging.
+     * @param array Determines if expected is an array value (true) or not (false);
+     * @return BiFunction used as validator.
+     * @apiNote Log entry template:<br>
+     * {@code "FIELD_NAME" (VALUE) found in file "PATH" isn't registered in "registryType"!}
+     */
+    public BiFunction<JsonElement, Path, Boolean> getRequiredRegisteredIDValidation(List<String> values, String registryType, boolean array) {
+        return (element, path) -> REQUIRED.apply(element, path) && getRegisteredIDValidation(values, registryType, array).apply(element, path);
     }
 
     /**
@@ -443,7 +475,8 @@ public class Validator {
      * @return BiFunction used as validator.
      */
     public BiFunction<JsonElement, Path, Boolean> getIllegalValuesValidation(List<String> values, boolean array) {
-        return (jsonElement, path) -> (array? assertArray(jsonElement, path): assertNotArray(jsonElement, path)) && getIllegalValuesValidation(values).apply(jsonElement, path);
+        return (jsonElement, path) ->
+            Objects.isNull(jsonElement) || (array? assertArray(jsonElement, path): assertNotArray(jsonElement, path)) && getIllegalValuesValidation(values).apply(jsonElement, path);
     }
 
     /**
@@ -493,7 +526,8 @@ public class Validator {
      * @return BiFunction used as validator.
      */
     public BiFunction<JsonElement, Path, Boolean> getAcceptsOnlyValidation(List<String> values, boolean array) {
-        return (jsonElement, path) -> (array? assertArray(jsonElement, path): assertNotArray(jsonElement, path)) && getAcceptsOnlyValidation(values).apply(jsonElement, path);
+        return (jsonElement, path) ->
+            Objects.isNull(jsonElement) || (array? assertArray(jsonElement, path): assertNotArray(jsonElement, path)) && getAcceptsOnlyValidation(values).apply(jsonElement, path);
     }
 
     /**

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/Validator.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/Validator.java
@@ -3,7 +3,6 @@ package com.ridanisaurus.emendatusenigmatica.loader;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Pair;
-import com.ridanisaurus.emendatusenigmatica.config.EEConfig;
 import net.minecraftforge.fml.loading.FMLPaths;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.LoggerFactory;
@@ -19,14 +18,6 @@ import java.util.function.Consumer;
  * @apiNote If not specified, the validator supports JsonArrays.
  */
 public class Validator {
-    //TODO: Validation of:
-    // - Strata - DONE
-    // - Compat Model - DONE
-    // - Material Model - DONE
-    // - All of the Material sub-models (pain) - DONE
-    // - Deposits
-    // - Code Cleanup
-    public static final boolean log = EEConfig.common.logConfigErrors.get();
     public static final ValidatorLogger LOGGER = new ValidatorLogger(LoggerFactory.getLogger("EE Data Validation"));
     /**
      * All values are accepted. Simply returns true.
@@ -143,7 +134,7 @@ public class Validator {
             try {
                 if (!data.isJsonPrimitive()) throw new ClassCastException();
                 double value = data.getAsDouble();
-                if (log && Math.ceil(value) > value) {
+                if (LOGGER.shouldLog && Math.ceil(value) > value) {
                     LOGGER.warn("\"%s\" in file \"%s\" should be an integer. Floating-point values are not supported for this field.".formatted(name, obfuscatePath(jsonPath)));
                 }
                 return true;
@@ -294,7 +285,7 @@ public class Validator {
         return (data, jsonPath) -> validateArray(data, jsonPath, (element, path) -> {
             try {
                 if (!element.isJsonPrimitive()) throw new ClassCastException();
-                if (log) {
+                if (LOGGER.shouldLog) {
                     double check = element.getAsDouble();
                     if (Math.ceil(check) > check) LOGGER.warn("\"%s\" in file \"%s\" should be an integer. Floating-point values are not supported for this field.".formatted(name, obfuscatePath(path)));
                 }
@@ -424,7 +415,6 @@ public class Validator {
      * to check if ID is registered in the provided registry. Marked as Required.
      * @param values List with IDS to check against.
      * @param registryType String with a registry type. Used only for logging.
-     * @param array Determines if expected is an array value (true) or not (false);
      * @return BiFunction used as validator.
      * @apiNote Log entry template:<br>
      * {@code "FIELD_NAME" (VALUE) found in file "PATH" isn't registered in "registryType"!}
@@ -700,7 +690,7 @@ public class Validator {
             JsonObject object = element.getAsJsonObject();
             AtomicBoolean validation = new AtomicBoolean(true);
 
-            if (log) object.entrySet().forEach(entry -> {
+            if (LOGGER.shouldLog) object.entrySet().forEach(entry -> {
                 if (!(validators.containsKey(entry.getKey()) || validators.containsKey(entry.getKey() + "_rg"))) {
                     LOGGER.warn("Unknown key (\"%s\") found in file \"%s\".".formatted(entry.getKey(), obfuscatePath(jsonPath)));
                 }

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/ValidatorLogger.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/ValidatorLogger.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 public class ValidatorLogger {
     private static final String spacer = "------------------------------------------------------------------------------------------------------------------------";
     private final Logger logger;
-    private final boolean shouldLog;
+    public final boolean shouldLog;
     private boolean spacerPrinted = false;
     private int warns = 0;
     private int errors = 0;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/ValidatorLogger.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/ValidatorLogger.java
@@ -1,0 +1,60 @@
+package com.ridanisaurus.emendatusenigmatica.loader;
+
+import org.slf4j.Logger;
+
+import java.util.Objects;
+
+/**
+ * Simple class that wraps around the Logger returned by LoggerFactory. Only used to make errors and warnings more readable.
+ */
+public class ValidatorLogger {
+    private static final String spacer = "------------------------------------------------------------------------------------------------------------------------";
+    private final Logger logger;
+    private boolean spacerPrinted = false;
+
+    public ValidatorLogger(Logger logger) {
+        Objects.requireNonNull(logger, "Can't create logger wrapper from Null logger!");
+        this.logger = logger;
+    }
+
+    public void info(String msg) {
+        log(msg, 0);
+    }
+
+    public void warn(String msg) {
+        log(msg, 1);
+    }
+
+    public void error(String msg) {
+        log(msg, 2);
+    }
+
+    public void debug(String msg) {
+        log(msg, -1);
+    }
+
+    public void log(String msg, int level) {
+        if (!spacerPrinted) {
+            printSpacer(level);
+            spacerPrinted = true;
+        }
+        switch (level) {
+            case 1 -> logger.warn(" " + msg);
+            case 2 -> logger.error(msg);
+            case -1 -> logger.debug(msg);
+            default -> logger.info(" " + msg);
+        }
+    }
+    public void restartSpacer() {
+        this.spacerPrinted = false;
+    }
+
+    public void printSpacer(int level) {
+        switch (level) {
+            case 1 -> logger.warn(" " + spacer);
+            case 2 -> logger.error(spacer);
+            case -1 -> logger.debug(spacer);
+            default -> logger.info(" " + spacer);
+        }
+    }
+}

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/ValidatorLogger.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/ValidatorLogger.java
@@ -1,5 +1,7 @@
 package com.ridanisaurus.emendatusenigmatica.loader;
 
+import com.mojang.datafixers.util.Pair;
+import com.ridanisaurus.emendatusenigmatica.config.EEConfig;
 import org.slf4j.Logger;
 
 import java.util.Objects;
@@ -10,29 +12,71 @@ import java.util.Objects;
 public class ValidatorLogger {
     private static final String spacer = "------------------------------------------------------------------------------------------------------------------------";
     private final Logger logger;
+    private final boolean shouldLog;
     private boolean spacerPrinted = false;
+    private int warns = 0;
+    private int errors = 0;
 
+    /**
+     * Creates instance of Validator Logger Wrapper.
+     * @param logger Logger to use.
+     */
     public ValidatorLogger(Logger logger) {
         Objects.requireNonNull(logger, "Can't create logger wrapper from Null logger!");
         this.logger = logger;
+        //TODO:
+        // Remove checks "if log" in places where methods below are used,
+        // this is now handled here by the logger wrapper.
+        shouldLog = EEConfig.common.logConfigErrors.get();
     }
 
+    /**
+     * Log the message at level INFO.
+     * @param msg Message to log.
+     */
     public void info(String msg) {
         log(msg, 0);
     }
 
+    /**
+     * Log the message at level WARN.
+     * @param msg Message to log.
+     */
     public void warn(String msg) {
-        log(msg, 1);
+        warns++;
+        if (shouldLog) log(msg, 1);
     }
 
+    /**
+     * Log the message at level ERROR.
+     * @param msg Message to log.
+     */
     public void error(String msg) {
-        log(msg, 2);
+        errors++;
+        if (shouldLog) log(msg, 2);
     }
 
+    /**
+     * Log the message at level DEBUG.
+     * @param msg Message to log.
+     */
     public void debug(String msg) {
         log(msg, -1);
     }
 
+    /**
+     * Used to log the message at specified level.
+     * Levels 1 and 2 aren't printed when "logConfigErrors" is set to false.
+     *<br>Levels:<br>
+     * <ul>
+     *     <li>-1 -> debug</li>
+     *     <li>0 -> info</li>
+     *     <li>1 -> warn</li>
+     *     <li>2 -> error</li>
+     * </ul>
+     * @param msg Message to log.
+     * @param level Integer level to print spacer at.
+     */
     public void log(String msg, int level) {
         if (!spacerPrinted) {
             printSpacer(level);
@@ -49,10 +93,33 @@ public class ValidatorLogger {
         this.spacerPrinted = false;
     }
 
+    /**
+     * Used to get logger statistics and reset them to 0.
+     * @return Pair with left -> warns / right -> errors
+     */
+    public Pair<Integer, Integer> getStatistics() {
+        var pair = new Pair<>(warns,errors);
+        warns = 0;
+        errors = 0;
+        return pair;
+    }
+
+    /**
+     * Used to print the spacer at specified level.
+     * Levels 1 and 2 aren't printed when "logConfigErrors" is set to false.
+     *<br>Levels:<br>
+     * <ul>
+     *     <li>-1 -> debug</li>
+     *     <li>0 -> info</li>
+     *     <li>1 -> warn</li>
+     *     <li>2 -> error</li>
+     * </ul>
+     * @param level Integer level to print spacer at.
+     */
     public void printSpacer(int level) {
         switch (level) {
-            case 1 -> logger.warn(" " + spacer);
-            case 2 -> logger.error(spacer);
+            case 1 -> {if (shouldLog) logger.warn(" " + spacer);}
+            case 2 -> {if (shouldLog) logger.error(spacer);}
             case -1 -> logger.debug(spacer);
             default -> logger.info(" " + spacer);
         }

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/ValidatorLogger.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/ValidatorLogger.java
@@ -1,6 +1,5 @@
 package com.ridanisaurus.emendatusenigmatica.loader;
 
-import com.mojang.datafixers.util.Pair;
 import com.ridanisaurus.emendatusenigmatica.config.EEConfig;
 import org.slf4j.Logger;
 
@@ -14,8 +13,6 @@ public class ValidatorLogger {
     private final Logger logger;
     public final boolean shouldLog;
     private boolean spacerPrinted = false;
-    private int warns = 0;
-    private int errors = 0;
 
     /**
      * Creates instance of Validator Logger Wrapper.
@@ -24,9 +21,6 @@ public class ValidatorLogger {
     public ValidatorLogger(Logger logger) {
         Objects.requireNonNull(logger, "Can't create logger wrapper from Null logger!");
         this.logger = logger;
-        //TODO:
-        // Remove checks "if log" in places where methods below are used,
-        // this is now handled here by the logger wrapper.
         shouldLog = EEConfig.common.logConfigErrors.get();
     }
 
@@ -43,7 +37,6 @@ public class ValidatorLogger {
      * @param msg Message to log.
      */
     public void warn(String msg) {
-        warns++;
         if (shouldLog) log(msg, 1);
     }
 
@@ -52,7 +45,6 @@ public class ValidatorLogger {
      * @param msg Message to log.
      */
     public void error(String msg) {
-        errors++;
         if (shouldLog) log(msg, 2);
     }
 
@@ -91,17 +83,6 @@ public class ValidatorLogger {
     }
     public void restartSpacer() {
         this.spacerPrinted = false;
-    }
-
-    /**
-     * Used to get logger statistics and reset them to 0.
-     * @return Pair with left -> warns / right -> errors
-     */
-    public Pair<Integer, Integer> getStatistics() {
-        var pair = new Pair<>(warns,errors);
-        warns = 0;
-        errors = 0;
-        return pair;
     }
 
     /**

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/EEDeposits.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/EEDeposits.java
@@ -83,6 +83,7 @@ public class EEDeposits {
 		Validator validator = new Validator("type");
 		ValidatorLogger LOGGER = Validator.LOGGER;
 
+		LOGGER.restartSpacer();
 		LOGGER.info("Validating and registering data for: Deposits");
 		depositJsonDefinitionsMap.forEach((path, element) -> {
 			LOGGER.restartSpacer();

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/EEDeposits.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/EEDeposits.java
@@ -60,9 +60,7 @@ public class EEDeposits {
 		DEPOSIT_PROCESSORS.put(DepositType.TEST.getType(), TestDepositProcessor::new);
 	}
 	public void load() {
-		if (DEPOSIT_PROCESSORS.isEmpty()) {
-			initProcessors();
-		}
+		if (DEPOSIT_PROCESSORS.isEmpty()) initProcessors();
 
 		if (DEPOSIT_TYPES.size() != DEPOSIT_PROCESSORS.size()) {
 			DEPOSIT_TYPES.clear();
@@ -98,9 +96,15 @@ public class EEDeposits {
 			DEPOSIT_IDS.add(element.get("registryName").getAsString());
 		});
 
-		for (IDepositProcessor activeProcessor : ACTIVE_PROCESSORS) {
-			activeProcessor.load();
+		LOGGER.restartSpacer();
+		if (LOGGER.shouldLog)  {
+			LOGGER.info("Finished validation and registration of data files.");
+		} else {
+			LOGGER.info("Finished registration of data files. Any validation errors that occurred, if any, have been hidden due to your current configuration file.");
 		}
+		LOGGER.printSpacer(0);
+
+		ACTIVE_PROCESSORS.forEach(IDepositProcessor::load);
 	}
 
 	public void setup() {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/DepositValidators.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/DepositValidators.java
@@ -1,8 +1,18 @@
 package com.ridanisaurus.emendatusenigmatica.loader.deposit.model;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.ridanisaurus.emendatusenigmatica.EmendatusEnigmatica;
+import com.ridanisaurus.emendatusenigmatica.api.EmendatusDataRegistry;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.EEDeposits;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.dense.DenseDepositConfigModel;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.dike.DikeDepositConfigModel;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.geode.GeodeDepositConfigModel;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sphere.SphereDepositConfigModel;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.test.TestDepositConfigModel;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.vanilla.VanillaDepositConfigModel;
+import com.ridanisaurus.emendatusenigmatica.loader.parser.model.MaterialModel;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
@@ -12,26 +22,160 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
+
+/**
+ * Class used to manage validators for each deposit type, and as a utility class for DepositValidators,
+ * containing a few of the specific validators that can be used between different config types.
+ * @see DepositValidators#get(String)
+ * @see DepositValidators#get(JsonElement)
+ * @see DepositValidators#getMaxYLevelValidation
+ */
 public class DepositValidators {
+    private static final EmendatusDataRegistry registry = EmendatusEnigmatica.getInstance().getLoader().getDataRegistry();
     private static final Map<String, Map<String, BiFunction<JsonElement, Path, Boolean>>> validators = new HashMap<>();
     static {
         Map<String, BiFunction<JsonElement, Path, Boolean>> common = new LinkedHashMap<>();
-        common.put("type", new Validator("type").getRequiredAcceptsOnlyValidation(EEDeposits.DEPOSIT_TYPES));
-        common.put("dimension", new Validator("dimension").RESOURCE_ID_REQUIRED);
-        common.put("biomes", new Validator("biomes").RESOURCE_ID);
-        common.put("registryName", new Validator("registryName").getIDValidation(EEDeposits.DEPOSIT_IDS));
+        common.put("type",          new Validator("type")       .getRequiredAcceptsOnlyValidation(EEDeposits.DEPOSIT_TYPES, false));
+        common.put("dimension",     new Validator("dimension")  .getRequiredResourceIDValidation(false));
+        common.put("biomes",        new Validator("biomes")     .getResourceIDValidation(true));
+        common.put("registryName",  new Validator("registryName").getIDValidation(EEDeposits.DEPOSIT_IDS));
         // This one should be overridden for each type, it's only as a "default" for an unknown type.
         common.put("config", new Validator("config").REQUIRED);
         validators.put("common", common);
         // Here you can add validators for specific Deposit Types. Take a note for each "type" all common validators are going to be added.
         // Add entry with the same key to override validator if it's not required for your type.
-//        validators.put(EEDeposits.DepositType.VANILLA.getType(),new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(VanillaDepositConfigModel.validators))));
-//        validators.put(EEDeposits.DepositType.DENSE.getType(),  new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(DenseDepositConfigModel.validators))));
-//        validators.put(EEDeposits.DepositType.DIKE.getType(),   new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(DikeDepositConfigModel.validators))));
-//        validators.put(EEDeposits.DepositType.GEODE.getType(),  new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(GeodeDepositConfigModel.validators))));
-//        validators.put(EEDeposits.DepositType.SPHERE.getType(), new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(SphereDepositConfigModel.validators))));
-//        validators.put(EEDeposits.DepositType.TEST.getType(),   new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(TestDepositConfigModel.validators))));
+        validators.put(EEDeposits.DepositType.VANILLA.getType(),new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(VanillaDepositConfigModel.validators, false))));
+        validators.put(EEDeposits.DepositType.SPHERE.getType(), new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(SphereDepositConfigModel.validators, false))));
+        validators.put(EEDeposits.DepositType.GEODE.getType(),  new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(GeodeDepositConfigModel.validators, false))));
+        validators.put(EEDeposits.DepositType.DENSE.getType(),  new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(DenseDepositConfigModel.validators, false))));
+        validators.put(EEDeposits.DepositType.DIKE.getType(),   new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(DikeDepositConfigModel.validators, false))));
+        validators.put(EEDeposits.DepositType.TEST.getType(),   new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(TestDepositConfigModel.validators, false))));
     }
+
+    /**
+     * Provider of MaxYLevelValidation. Requires use of _rg suffix to work.
+     * @apiNote This is meant to be modified and moved to {@link Validator} class!
+     */
+    public static BiFunction<JsonElement, Path, Boolean> getMaxYLevelValidation(Validator validator, String minName) {
+        //TODO: Add additional configuration option and move it to validator
+        return (element, path) -> {
+            if (!validator.assertParentObject(element, path)) return false;
+            JsonObject parent = element.getAsJsonObject();
+            JsonElement value = parent.get(validator.getName());
+            JsonElement min = parent.get(minName);
+            int minValue = -64;
+
+            if (!validator.REQUIRED.apply(value, path)) return false;
+
+            if (Objects.isNull(min)) {
+                LOGGER.warn("Field \"%s\" is missing! Can't accurately verify \"%s\" in file \"%s\".".formatted(minName, validator.getName(), Validator.obfuscatePath(path)));
+            } else {
+                try {
+                    if (!min.isJsonPrimitive()) throw new ClassCastException();
+                    minValue = min.getAsInt();
+                    if (minValue > 320) {
+                        LOGGER.error("Field \"%s\" is above max 320! Can't accurately verify \"%s\" in file \"%s\".".formatted(minName, validator.getName(), Validator.obfuscatePath(path)));
+                        minValue = -64;
+                    }
+                } catch (ClassCastException e) {
+                    LOGGER.error("Field \"%s\" requires a Numeric value! Can't accurately verify \"%s\" in file \"%s\".".formatted(minName, validator.getName(), Validator.obfuscatePath(path)));
+                }
+            }
+
+            return validator.getIntRange(minValue, 320, false).apply(value, path);
+        };
+    }
+
+    /**
+     * Used to get a validator for Material Field, when Block and Tag fields are as an alternatives.
+     * Requires usage of _rg suffix.
+     * @param validator Validator to use for the template.
+     * @return BiFunction used as a validator.
+     */
+    public static BiFunction<JsonElement, Path, Boolean> getFullMaterialValidation(Validator validator) {
+        return (element, path) -> {
+            if (!validator.assertParentObject(element, path)) return false;
+            JsonObject parent = element.getAsJsonObject();
+            JsonElement blockElement = parent.get("block");
+            JsonElement materialElement = parent.get("material");
+            JsonElement tagElement = parent.get("tag");
+
+            if (Objects.isNull(blockElement) && Objects.isNull(materialElement) && Objects.isNull(tagElement)) {
+                LOGGER.error("Either \"block\", \"material\" or \"tag\" is required to be present in the file \"%s\".".formatted(Validator.obfuscatePath(path)));
+                return false;
+            }
+            if (
+                    (Objects.nonNull(materialElement) && (Objects.nonNull(blockElement) || Objects.nonNull(tagElement))) ||
+                    (Objects.nonNull(blockElement) && Objects.nonNull(tagElement))
+            ) {
+                LOGGER.error("\"tag\", \"block\" and \"material\" can't be present at the same time in the file \"%s\".".formatted(Validator.obfuscatePath(path)));
+                return false;
+            }
+            if (Objects.nonNull(blockElement)) return true;
+            if (Objects.nonNull(tagElement)) return true;
+            return getOnlyMaterialValidation(validator).apply(materialElement, path);
+        };
+    }
+
+    /**
+     * Used to get a validator for Material field, when Block Field is an alternative. Requires usage of _rg suffix.
+     * @param validator Validator to use for the template.
+     * @return BiFunction used as a validator.
+     */
+    public static BiFunction<JsonElement, Path, Boolean> getBlockMaterialValidation(Validator validator) {
+        return (element, path) -> {
+            if (!validator.assertParentObject(element, path)) return false;
+            JsonObject parent = element.getAsJsonObject();
+            JsonElement blockElement = parent.get("block");
+            JsonElement materialElement = parent.get("material");
+
+            if (Objects.isNull(blockElement) && Objects.isNull(materialElement)) {
+                LOGGER.error("Either \"block\" or \"material\" is required to be present in the file \"%s\".".formatted(Validator.obfuscatePath(path)));
+                return false;
+            }
+            if (Objects.nonNull(blockElement) && Objects.nonNull(materialElement)) {
+                LOGGER.error("\"block\" and \"material\" can't be present at the same time in the file \"%s\".".formatted(Validator.obfuscatePath(path)));
+                return false;
+            }
+            if (Objects.nonNull(blockElement)) return true;
+            return getOnlyMaterialValidation(validator).apply(materialElement, path);
+        };
+    }
+
+    /**
+     * Used to get a validator for Material Field. Checks if Material under that ID is registered and if it contains "ore" as processed type.
+     * @param validator Validator to use for the template.
+     * @return BiFunction used as a validator
+     * @apiNote This does not check for anything related to other possible fields, like block or tag.
+     * Use {@link DepositValidators#getBlockMaterialValidation(Validator)} instead.
+     */
+    public static BiFunction<JsonElement, Path, Boolean> getOnlyMaterialValidation(Validator validator) {
+        return (element, path) -> {
+            if (!validator.getRequiredNonEmptyValidation(false).apply(element, path)) return false;
+            String materialID = element.getAsString();
+            MaterialModel material = registry.getMaterialByID(materialID);
+            if (Objects.isNull(material)) {
+                LOGGER.error("\"material\" (%s) found in file \"%s\" isn't registered in \"Material Registry\"!".formatted(materialID, Validator.obfuscatePath(path)));
+                return false;
+            }
+            if (!material.getProcessedTypes().contains("ore")) {
+                LOGGER.error(
+                    "Specified \"material\" (%s) found in file \"%s\" doesn't contain \"ore\" as a processed type. Usage of \"material\" field is prohibited in this situation."
+                    .formatted(materialID, Validator.obfuscatePath(path))
+                );
+                return false;
+            }
+            return true;
+        };
+    }
+
+    /**
+     * Used to get validators for a provided deposit type.
+     * @param type Deposit type to get validators for.
+     * @return Map with validators for a specified type + common validators.
+     * @apiNote Returns only common validators if a specified type is not registered.
+     */
     public static Map<String, BiFunction<JsonElement, Path, Boolean>> get(String type) {
         var commonValidators = new LinkedHashMap<>(validators.get("common"));
         if (!type.equals("common")) {
@@ -41,6 +185,12 @@ public class DepositValidators {
         return commonValidators;
     }
 
+    /**
+     * Used to get validators for a provided JsonElement containing a deposit type.
+     * @param typeElement JsonElement with a Deposit type to get validators for.
+     * @return Map with validators for a specified type + common validators.
+     * @apiNote Returns only common validators if a specified type is not registered, or the typeElement is null / not Primitive.
+     */
     public static Map<String, BiFunction<JsonElement, Path, Boolean>> get(@Nullable JsonElement typeElement) {
         if (Objects.isNull(typeElement) || !typeElement.isJsonPrimitive()) return get("common");
         return get(typeElement.getAsString());

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/DepositValidators.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/DepositValidators.java
@@ -54,40 +54,6 @@ public class DepositValidators {
     }
 
     /**
-     * Provider of MaxYLevelValidation. Requires use of _rg suffix to work.
-     * @apiNote This is meant to be modified and moved to {@link Validator} class!
-     */
-    public static BiFunction<JsonElement, Path, Boolean> getMaxYLevelValidation(Validator validator, String minName) {
-        //TODO: Add additional configuration option and move it to validator
-        return (element, path) -> {
-            if (!validator.assertParentObject(element, path)) return false;
-            JsonObject parent = element.getAsJsonObject();
-            JsonElement value = parent.get(validator.getName());
-            JsonElement min = parent.get(minName);
-            int minValue = -64;
-
-            if (!validator.REQUIRED.apply(value, path)) return false;
-
-            if (Objects.isNull(min)) {
-                LOGGER.warn("Field \"%s\" is missing! Can't accurately verify \"%s\" in file \"%s\".".formatted(minName, validator.getName(), Validator.obfuscatePath(path)));
-            } else {
-                try {
-                    if (!min.isJsonPrimitive()) throw new ClassCastException();
-                    minValue = min.getAsInt();
-                    if (minValue > 320) {
-                        LOGGER.error("Field \"%s\" is above max 320! Can't accurately verify \"%s\" in file \"%s\".".formatted(minName, validator.getName(), Validator.obfuscatePath(path)));
-                        minValue = -64;
-                    }
-                } catch (ClassCastException e) {
-                    LOGGER.error("Field \"%s\" requires a Numeric value! Can't accurately verify \"%s\" in file \"%s\".".formatted(minName, validator.getName(), Validator.obfuscatePath(path)));
-                }
-            }
-
-            return validator.getIntRange(minValue, 320, false).apply(value, path);
-        };
-    }
-
-    /**
      * Used to get a validator for Material Field, when Block and Tag fields are as an alternatives.
      * Requires usage of _rg suffix.
      * @param validator Validator to use for the template.

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/DepositValidators.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/DepositValidators.java
@@ -1,0 +1,41 @@
+package com.ridanisaurus.emendatusenigmatica.loader.deposit.model;
+
+import com.google.gson.JsonElement;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.EEDeposits;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+public class DepositValidators {
+    private static final Map<String, Map<String, BiFunction<JsonElement, Path, Boolean>>> validators = new HashMap<>();
+    static {
+        Map<String, BiFunction<JsonElement, Path, Boolean>> common = new LinkedHashMap<>();
+        common.put("type", new Validator("type").getRequiredAcceptsOnlyValidation(EEDeposits.DEPOSIT_TYPES));
+        common.put("dimension", new Validator("dimension").RESOURCE_ID_REQUIRED);
+        common.put("biomes", new Validator("biomes").RESOURCE_ID);
+        common.put("registryName", new Validator("registryName").getIDValidation(EEDeposits.DEPOSIT_IDS));
+        validators.put("common", common);
+        // Here you can add validators for specific Deposit Types. Take a note for each "type" all common validators are going to be added.
+        // Add entry with the same key to override validator if it's not required for your type.
+        //TODO: Add validations for all config models. Those... aren't identical so like, 5 different maps time.
+    }
+    public static Map<String, BiFunction<JsonElement, Path, Boolean>> get(String type) {
+        var commonValidators = new LinkedHashMap<>(validators.get("common"));
+        if (!type.equals("common")) {
+            var typeValidators = validators.get(type);
+            if (Objects.nonNull(typeValidators)) commonValidators.putAll(typeValidators);
+        }
+        return commonValidators;
+    }
+
+    public static Map<String, BiFunction<JsonElement, Path, Boolean>> get(@Nullable JsonElement typeElement) {
+        if (Objects.isNull(typeElement) || !typeElement.isJsonPrimitive()) return get("common");
+        return get(typeElement.getAsString());
+    }
+}

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/DepositValidators.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/DepositValidators.java
@@ -20,10 +20,17 @@ public class DepositValidators {
         common.put("dimension", new Validator("dimension").RESOURCE_ID_REQUIRED);
         common.put("biomes", new Validator("biomes").RESOURCE_ID);
         common.put("registryName", new Validator("registryName").getIDValidation(EEDeposits.DEPOSIT_IDS));
+        // This one should be overridden for each type, it's only as a "default" for an unknown type.
+        common.put("config", new Validator("config").REQUIRED);
         validators.put("common", common);
         // Here you can add validators for specific Deposit Types. Take a note for each "type" all common validators are going to be added.
         // Add entry with the same key to override validator if it's not required for your type.
-        //TODO: Add validations for all config models. Those... aren't identical so like, 5 different maps time.
+//        validators.put(EEDeposits.DepositType.VANILLA.getType(),new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(VanillaDepositConfigModel.validators))));
+//        validators.put(EEDeposits.DepositType.DENSE.getType(),  new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(DenseDepositConfigModel.validators))));
+//        validators.put(EEDeposits.DepositType.DIKE.getType(),   new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(DikeDepositConfigModel.validators))));
+//        validators.put(EEDeposits.DepositType.GEODE.getType(),  new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(GeodeDepositConfigModel.validators))));
+//        validators.put(EEDeposits.DepositType.SPHERE.getType(), new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(SphereDepositConfigModel.validators))));
+//        validators.put(EEDeposits.DepositType.TEST.getType(),   new LinkedHashMap<>(Map.of("config", new Validator("config").getRequiredObjectValidation(TestDepositConfigModel.validators))));
     }
     public static Map<String, BiFunction<JsonElement, Path, Boolean>> get(String type) {
         var commonValidators = new LinkedHashMap<>(validators.get("common"));

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/common/CommonBlockDefinitionModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/common/CommonBlockDefinitionModel.java
@@ -2,6 +2,7 @@ package com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -21,7 +22,7 @@ public class CommonBlockDefinitionModel {
 	protected final int min;
 	protected final int max;
 
-	public CommonBlockDefinitionModel(String block, String tag, String material, int weight, int min, int max) {
+	public CommonBlockDefinitionModel(@Nullable String block, @Nullable String tag, @Nullable String material, int weight, int min, int max) {
 		this.block = block;
 		this.tag = tag;
 		this.material = material;
@@ -30,15 +31,15 @@ public class CommonBlockDefinitionModel {
 		this.max = max;
 	}
 
-	public String getBlock() {
+	public @Nullable String getBlock() {
 		return block;
 	}
 
-	public String getTag() {
+	public @Nullable String getTag() {
 		return tag;
 	}
 
-	public String getMaterial() {
+	public @Nullable String getMaterial() {
 		return material;
 	}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/common/CommonBlockDefinitionModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/common/CommonBlockDefinitionModel.java
@@ -1,10 +1,22 @@
 package com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.EEDeposits;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.DepositValidators;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
 
 public class CommonBlockDefinitionModel {
 	public static final Codec<CommonBlockDefinitionModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -21,6 +33,56 @@ public class CommonBlockDefinitionModel {
 	protected final int weight;
 	protected final int min;
 	protected final int max;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 * @implNote Validators of min/max are using simplified temp check for checking if the type is dike.<br>
+	 * If you need to pass parent to those validators for any other reason,
+	 * modify this implementation to check for specific field for those validators!.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("block", 	new Validator("block").getResourceIDValidation(false));
+		validators.put("tag", 		new Validator("tag").getResourceIDValidation(false));
+		validators.put("weight", 	new Validator("weight").REQUIRES_INT);
+		validators.put("material_rg", DepositValidators.getFullMaterialValidation(new Validator("material")));
+
+		Validator minValidator = new Validator("min");
+		Validator maxValidator = new Validator("max");
+		validators.put("min_rg", (element, path) -> {
+			if (!minValidator.assertParentObject(element, path)) return false;
+			JsonObject parent = element.getAsJsonObject();
+			JsonElement value = parent.get(minValidator.getName());
+
+			if (Objects.isNull(value)) return true;
+			if (!Validator.checkForTEMP(parent, path, false)) {
+				LOGGER.warn(
+					"\"%s\" should not be present in file \"%s\", as it doesn't take effect on types different than \"%s\"!"
+					.formatted(minValidator.getName(), Validator.obfuscatePath(path), EEDeposits.DepositType.DIKE.getType())
+				);
+			}
+
+			return minValidator.REQUIRES_INT.apply(value, path);
+		});
+		validators.put("max_rg", (element, path) -> {
+			if (!maxValidator.assertParentObject(element, path)) return false;
+			JsonObject parent = element.getAsJsonObject();
+			JsonElement value = parent.get(minValidator.getName());
+
+			if (Objects.isNull(value)) return true;
+			if (!Validator.checkForTEMP(parent, path, false)) {
+				LOGGER.warn(
+					"\"%s\" should not be present in file \"%s\", as it doesn't take effect on types different than \"%s\"!"
+					.formatted(maxValidator.getName(), Validator.obfuscatePath(path), EEDeposits.DepositType.DIKE.getType())
+				);
+			}
+
+			return DepositValidators.getMaxYLevelValidation(maxValidator, "min").apply(parent, path);
+		});
+	}
 
 	public CommonBlockDefinitionModel(@Nullable String block, @Nullable String tag, @Nullable String material, int weight, int min, int max) {
 		this.block = block;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/common/CommonBlockDefinitionModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/common/CommonBlockDefinitionModel.java
@@ -80,7 +80,7 @@ public class CommonBlockDefinitionModel {
 				);
 			}
 
-			return DepositValidators.getMaxYLevelValidation(maxValidator, "min").apply(parent, path);
+			return maxValidator.getMaxYLevelValidation("min").apply(parent, path);
 		});
 	}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dense/DenseDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dense/DenseDepositConfigModel.java
@@ -24,13 +24,18 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.deposit.model.dense;
 
+import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
 
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 public class DenseDepositConfigModel {
 	public static final Codec<DenseDepositConfigModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -56,6 +61,18 @@ public class DenseDepositConfigModel {
 	public final String rarity;
 	public final boolean generateSamples;
 	public final List<SampleBlockDefinitionModel> sampleBlocks;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("protection", new Validator("protection").REQUIRES_INT);
+		validators.put("durability", new Validator("durability").REQUIRES_INT);
+	}
 
 	public DenseDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {
 		this.blocks = blocks;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dense/DenseDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dense/DenseDepositConfigModel.java
@@ -28,8 +28,10 @@ import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.DepositValidators;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
+import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
 
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -70,8 +72,16 @@ public class DenseDepositConfigModel {
 	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
 
 	static {
-		validators.put("protection", new Validator("protection").REQUIRES_INT);
-		validators.put("durability", new Validator("durability").REQUIRES_INT);
+		validators.put("blocks", 		new Validator("blocks").getRequiredObjectValidation(CommonBlockDefinitionModel.validators, true));
+		validators.put("fillerTypes", 	new Validator("fillerTypes").getRequiredRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry", true));
+		validators.put("chance", 		new Validator("chance").getRequiredIntRange(1, 100, false));
+		validators.put("size", 			new Validator("size").getRequiredIntRange(1, 48, false));
+		validators.put("minYLevel", 	new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
+		validators.put("maxYLevel_rg", 	DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
+		validators.put("placement", 	new Validator("placement").getAcceptsOnlyValidation(List.of("uniform", "triangle"), false));
+		validators.put("rarity", 		new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare"), false));
+		validators.put("generateSamples",new Validator("generateSamples").REQUIRES_BOOLEAN);
+		validators.put("sampleBlocks", 	new Validator("sampleBlocks").getObjectValidation(SampleBlockDefinitionModel.validators, true));
 	}
 
 	public DenseDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dense/DenseDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dense/DenseDepositConfigModel.java
@@ -28,7 +28,6 @@ import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
-import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.DepositValidators;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
@@ -77,11 +76,12 @@ public class DenseDepositConfigModel {
 		validators.put("chance", 		new Validator("chance").getRequiredIntRange(1, 100, false));
 		validators.put("size", 			new Validator("size").getRequiredIntRange(1, 48, false));
 		validators.put("minYLevel", 	new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
-		validators.put("maxYLevel_rg", 	DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
+		validators.put("maxYLevel_rg", 	new Validator("maxYLevel").getMaxYLevelValidation("minYLevel"));
 		validators.put("placement", 	new Validator("placement").getAcceptsOnlyValidation(List.of("uniform", "triangle"), false));
 		validators.put("rarity", 		new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare"), false));
 		validators.put("generateSamples",new Validator("generateSamples").REQUIRES_BOOLEAN);
-		validators.put("sampleBlocks", 	new Validator("sampleBlocks").getObjectValidation(SampleBlockDefinitionModel.validators, true));
+		Validator sampleValidator = new Validator("sampleBlocks");
+		validators.put("sampleBlocks_rg", sampleValidator.getIfOtherFieldSet("generateSamples", sampleValidator.getRequiredObjectValidation(SampleBlockDefinitionModel.validators, true)));
 	}
 
 	public DenseDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dense/DenseDepositModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dense/DenseDepositModel.java
@@ -53,7 +53,7 @@ public class DenseDepositModel extends CommonDepositModelBase {
 	}
 
 	public int getChance() {
-		if (config.chance < 1 || config.chance > 100) throw new IllegalArgumentException("Chance for " + name + " is out of Range [1 - 100]");
+//		if (config.chance < 1 || config.chance > 100) throw new IllegalArgumentException("Chance for " + name + " is out of Range [1 - 100]");
 		return config.chance;
 	}
 
@@ -62,37 +62,37 @@ public class DenseDepositModel extends CommonDepositModelBase {
 	}
 
 	public int getMaxYLevel() {
-		if (config.maxYLevel < -64 || config.maxYLevel > 320) throw new IllegalArgumentException("Max Y for " + name + " is out of Range [-64 - 320]");
+//		if (config.maxYLevel < -64 || config.maxYLevel > 320) throw new IllegalArgumentException("Max Y for " + name + " is out of Range [-64 - 320]");
 		return config.maxYLevel;
 	}
 
 	public int getMinYLevel() {
-		if (config.minYLevel < -64 || config.minYLevel > 320) throw new IllegalArgumentException("Min Y for " + name + " is out of Range [-64 - 320]");
+//		if (config.minYLevel < -64 || config.minYLevel > 320) throw new IllegalArgumentException("Min Y for " + name + " is out of Range [-64 - 320]");
 		return config.minYLevel;
 	}
 
 	public List<CommonBlockDefinitionModel> getBlocks() {
-		if (config.blocks.isEmpty()) throw new IllegalArgumentException("Blocks for " + name + " cannot be empty.");
+//		if (config.blocks.isEmpty()) throw new IllegalArgumentException("Blocks for " + name + " cannot be empty.");
 		return config.blocks;
 	}
 
 	public List<String> getFillerTypes() {
-		if (config.fillerTypes.isEmpty()) throw new IllegalArgumentException("Filler Types for " + name + " cannot be empty.");
+//		if (config.fillerTypes.isEmpty()) throw new IllegalArgumentException("Filler Types for " + name + " cannot be empty.");
 		return config.fillerTypes;
 	}
 
 	public int getSize() {
-		if (config.size < 1 || config.size > 48) throw new IllegalArgumentException("Size for " + name + " is out of Range [1 - 48]");
+//		if (config.size < 1 || config.size > 48) throw new IllegalArgumentException("Size for " + name + " is out of Range [1 - 48]");
 		return config.size;
 	}
 
 	public String getPlacement() {
-		if (!config.placement.equals("uniform") && !config.placement.equals("triangle")) throw new IllegalArgumentException("Placement for " + name + " is invalid.");
+//		if (!config.placement.equals("uniform") && !config.placement.equals("triangle")) throw new IllegalArgumentException("Placement for " + name + " is invalid.");
 		return config.placement;
 	}
 
 	public String getRarity() {
-		if (!config.rarity.equals("common") && !config.rarity.equals("rare")) throw new IllegalArgumentException("Rarity for " + name + " is invalid.");
+//		if (!config.rarity.equals("common") && !config.rarity.equals("rare")) throw new IllegalArgumentException("Rarity for " + name + " is invalid.");
 		return config.rarity;
 	}
 
@@ -101,7 +101,7 @@ public class DenseDepositModel extends CommonDepositModelBase {
 	}
 
 	public List<SampleBlockDefinitionModel> getSampleBlocks() {
-		if (hasSamples() && config.sampleBlocks.isEmpty()) throw new IllegalArgumentException("Sample Blocks for " + name + " cannot be empty if generateSamples is set to true.");
+//		if (hasSamples() && config.sampleBlocks.isEmpty()) throw new IllegalArgumentException("Sample Blocks for " + name + " cannot be empty if generateSamples is set to true.");
 		return config.sampleBlocks;
 	}
 }

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dike/DikeDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dike/DikeDepositConfigModel.java
@@ -54,11 +54,12 @@ public class DikeDepositConfigModel {
 		//TODO: Verify the real maximum size for dikes.
 		validators.put("size", 			new Validator("size").getRequiredIntRange(1, 64, false));
 		validators.put("minYLevel", 	new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
-		validators.put("maxYLevel_rg", 	DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
+		validators.put("maxYLevel_rg", 	new Validator("maxYLevel").getMaxYLevelValidation("minYLevel"));
 		validators.put("placement", 	new Validator("placement").getAcceptsOnlyValidation(List.of("uniform", "triangle"), false));
 		validators.put("rarity", 		new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare"), false));
 		validators.put("generateSamples",new Validator("generateSamples").REQUIRES_BOOLEAN);
-		validators.put("sampleBlocks", 	new Validator("sampleBlocks").getObjectValidation(SampleBlockDefinitionModel.validators, true));
+		Validator sampleValidator = new Validator("sampleBlocks");
+		validators.put("sampleBlocks_rg", sampleValidator.getIfOtherFieldSet("generateSamples", sampleValidator.getRequiredObjectValidation(SampleBlockDefinitionModel.validators, true)));
 	}
 
 	public DikeDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dike/DikeDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dike/DikeDepositConfigModel.java
@@ -1,11 +1,17 @@
 package com.ridanisaurus.emendatusenigmatica.loader.deposit.model.dike;
 
+import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
 
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 public class DikeDepositConfigModel {
 	public static final Codec<DikeDepositConfigModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -31,6 +37,18 @@ public class DikeDepositConfigModel {
 	public final String rarity;
 	public final boolean generateSamples;
 	public final List<SampleBlockDefinitionModel> sampleBlocks;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("protection", new Validator("protection").REQUIRES_INT);
+		validators.put("durability", new Validator("durability").REQUIRES_INT);
+	}
 
 	public DikeDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {
 		this.blocks = blocks;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dike/DikeDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dike/DikeDepositConfigModel.java
@@ -4,8 +4,10 @@ import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.DepositValidators;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
+import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
 
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -46,8 +48,17 @@ public class DikeDepositConfigModel {
 	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
 
 	static {
-		validators.put("protection", new Validator("protection").REQUIRES_INT);
-		validators.put("durability", new Validator("durability").REQUIRES_INT);
+		validators.put("blocks_rg", 	new Validator("blocks").getPassParentToValidators(CommonBlockDefinitionModel.validators, true, true));
+		validators.put("fillerTypes", 	new Validator("fillerTypes").getRequiredRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry", true));
+		validators.put("chance", 		new Validator("chance").getRequiredIntRange(1, 100, false));
+		//TODO: Verify the real maximum size for dikes.
+		validators.put("size", 			new Validator("size").getRequiredIntRange(1, 64, false));
+		validators.put("minYLevel", 	new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
+		validators.put("maxYLevel_rg", 	DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
+		validators.put("placement", 	new Validator("placement").getAcceptsOnlyValidation(List.of("uniform", "triangle"), false));
+		validators.put("rarity", 		new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare"), false));
+		validators.put("generateSamples",new Validator("generateSamples").REQUIRES_BOOLEAN);
+		validators.put("sampleBlocks", 	new Validator("sampleBlocks").getObjectValidation(SampleBlockDefinitionModel.validators, true));
 	}
 
 	public DikeDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dike/DikeDepositModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dike/DikeDepositModel.java
@@ -58,7 +58,7 @@ public class DikeDepositModel extends CommonDepositModelBase {
 	}
 
 	public int getSize() {
-		// TODO: Check the Dike Size parameters
+		// See loader/deposit/model/dike/DikeDepositConfigModel.javaDikeDepositConfigModel for validation of the size.
 //		if (config.size < 1 || config.size > 16) throw new IllegalArgumentException("Size for " + name + " is out of Range [1 - 16]");
 		return config.size;
 	}

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dike/DikeDepositModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/dike/DikeDepositModel.java
@@ -29,7 +29,7 @@ public class DikeDepositModel extends CommonDepositModelBase {
 	}
 
 	public int getChance() {
-		if (config.chance < 1 || config.chance > 100) throw new IllegalArgumentException("Chance for " + name + " is out of Range [1 - 100]");
+//		if (config.chance < 1 || config.chance > 100) throw new IllegalArgumentException("Chance for " + name + " is out of Range [1 - 100]");
 		return config.chance;
 	}
 
@@ -38,38 +38,37 @@ public class DikeDepositModel extends CommonDepositModelBase {
 	}
 
 	public int getMaxYLevel() {
-		if (config.maxYLevel < -64 || config.maxYLevel > 320) throw new IllegalArgumentException("Max Y for " + name + " is out of Range [-64 - 320]");
+//		if (config.maxYLevel < -64 || config.maxYLevel > 320) throw new IllegalArgumentException("Max Y for " + name + " is out of Range [-64 - 320]");
 		return config.maxYLevel;
 	}
 
 	public int getMinYLevel() {
-		if (config.minYLevel < -64 || config.minYLevel > 320) throw new IllegalArgumentException("Min Y for " + name + " is out of Range [-64 - 320]");
+//		if (config.minYLevel < -64 || config.minYLevel > 320) throw new IllegalArgumentException("Min Y for " + name + " is out of Range [-64 - 320]");
 		return config.minYLevel;
 	}
 
 	public List<CommonBlockDefinitionModel> getBlocks() {
-		if (config.blocks.isEmpty()) throw new IllegalArgumentException("Blocks for " + name + " cannot be empty.");
+//		if (config.blocks.isEmpty()) throw new IllegalArgumentException("Blocks for " + name + " cannot be empty.");
 		return config.blocks;
 	}
 
 	public List<String> getFillerTypes() {
-		if (config.fillerTypes.isEmpty()) throw new IllegalArgumentException("Filler Types for " + name + " cannot be empty.");
+//		if (config.fillerTypes.isEmpty()) throw new IllegalArgumentException("Filler Types for " + name + " cannot be empty.");
 		return config.fillerTypes;
 	}
 
 	public int getSize() {
-		// See loader/deposit/model/dike/DikeDepositConfigModel.javaDikeDepositConfigModel for validation of the size.
 //		if (config.size < 1 || config.size > 16) throw new IllegalArgumentException("Size for " + name + " is out of Range [1 - 16]");
 		return config.size;
 	}
 
 	public String getPlacement() {
-		if (!config.placement.equals("uniform") && !config.placement.equals("triangle")) throw new IllegalArgumentException("Placement for " + name + " is invalid.");
+//		if (!config.placement.equals("uniform") && !config.placement.equals("triangle")) throw new IllegalArgumentException("Placement for " + name + " is invalid.");
 		return config.placement;
 	}
 
 	public String getRarity() {
-		if (!config.rarity.equals("common") && !config.rarity.equals("rare")) throw new IllegalArgumentException("Rarity for " + name + " is invalid.");
+//		if (!config.rarity.equals("common") && !config.rarity.equals("rare")) throw new IllegalArgumentException("Rarity for " + name + " is invalid.");
 		return config.rarity;
 	}
 
@@ -78,7 +77,7 @@ public class DikeDepositModel extends CommonDepositModelBase {
 	}
 
 	public List<SampleBlockDefinitionModel> getSampleBlocks() {
-		if (hasSamples() && config.sampleBlocks.isEmpty()) throw new IllegalArgumentException("Sample Blocks for " + name + " cannot be empty if generateSamples is set to true.");
+//		if (hasSamples() && config.sampleBlocks.isEmpty()) throw new IllegalArgumentException("Sample Blocks for " + name + " cannot be empty if generateSamples is set to true.");
 		return config.sampleBlocks;
 	}
 }

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/geode/GeodeDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/geode/GeodeDepositConfigModel.java
@@ -4,8 +4,10 @@ import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.DepositValidators;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
+import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
 
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -54,8 +56,20 @@ public class GeodeDepositConfigModel {
 	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
 
 	static {
-		validators.put("protection", new Validator("protection").REQUIRES_INT);
-		validators.put("durability", new Validator("durability").REQUIRES_INT);
+		validators.put("outerShellBlocks", 	new Validator("outerShellBlocks").getRequiredObjectValidation(CommonBlockDefinitionModel.validators, true));
+		validators.put("innerShellBlocks",	new Validator("innerShellBlocks").getRequiredObjectValidation(CommonBlockDefinitionModel.validators, true));
+		validators.put("innerBlocks", 		new Validator("innerBlocks").getRequiredObjectValidation(CommonBlockDefinitionModel.validators, true));
+		validators.put("fillBlocks", 		new Validator("fillBlocks").getRequiredObjectValidation(CommonBlockDefinitionModel.validators, true));
+		validators.put("fillerTypes", 		new Validator("fillerTypes").getRequiredRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry", true));
+		validators.put("clusters", 			new Validator("clusters").getResourceIDValidation(true));
+		validators.put("chance", 			new Validator("chance").getRequiredIntRange(1, 100, false));
+		validators.put("crackChance", 		new Validator("crackChance").getRequiredRange(0, 1, false));
+		validators.put("minYLevel", 		new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
+		validators.put("maxYLevel_rg", 		DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
+		validators.put("placement", 	new Validator("placement").getAcceptsOnlyValidation(List.of("uniform", "triangle"), false));
+		validators.put("rarity", 			new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare"), false));
+		validators.put("generateSamples",	new Validator("generateSamples").REQUIRES_BOOLEAN);
+		validators.put("sampleBlocks", 		new Validator("sampleBlocks").getObjectValidation(SampleBlockDefinitionModel.validators, true));
 	}
 
 	public GeodeDepositConfigModel(List<CommonBlockDefinitionModel> outerShellBlocks, List<CommonBlockDefinitionModel> innerShellBlocks, List<CommonBlockDefinitionModel> innerBlocks, List<CommonBlockDefinitionModel> fillBlocks, List<String> fillerTypes, List<String> clusters, int chance, double crackChance, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/geode/GeodeDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/geode/GeodeDepositConfigModel.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
-import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.DepositValidators;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
@@ -65,11 +64,12 @@ public class GeodeDepositConfigModel {
 		validators.put("chance", 			new Validator("chance").getRequiredIntRange(1, 100, false));
 		validators.put("crackChance", 		new Validator("crackChance").getRequiredRange(0, 1, false));
 		validators.put("minYLevel", 		new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
-		validators.put("maxYLevel_rg", 		DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
-		validators.put("placement", 	new Validator("placement").getAcceptsOnlyValidation(List.of("uniform", "triangle"), false));
+		validators.put("maxYLevel_rg", 		new Validator("maxYLevel").getMaxYLevelValidation("minYLevel"));
+		validators.put("placement", 		new Validator("placement").getAcceptsOnlyValidation(List.of("uniform", "triangle"), false));
 		validators.put("rarity", 			new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare"), false));
 		validators.put("generateSamples",	new Validator("generateSamples").REQUIRES_BOOLEAN);
-		validators.put("sampleBlocks", 		new Validator("sampleBlocks").getObjectValidation(SampleBlockDefinitionModel.validators, true));
+		Validator sampleValidator = new Validator("sampleBlocks");
+		validators.put("sampleBlocks_rg", sampleValidator.getIfOtherFieldSet("generateSamples", sampleValidator.getRequiredObjectValidation(SampleBlockDefinitionModel.validators, true)));
 	}
 
 	public GeodeDepositConfigModel(List<CommonBlockDefinitionModel> outerShellBlocks, List<CommonBlockDefinitionModel> innerShellBlocks, List<CommonBlockDefinitionModel> innerBlocks, List<CommonBlockDefinitionModel> fillBlocks, List<String> fillerTypes, List<String> clusters, int chance, double crackChance, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/geode/GeodeDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/geode/GeodeDepositConfigModel.java
@@ -1,11 +1,17 @@
 package com.ridanisaurus.emendatusenigmatica.loader.deposit.model.geode;
 
+import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
 
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 public class GeodeDepositConfigModel {
 	public static final Codec<GeodeDepositConfigModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -39,6 +45,18 @@ public class GeodeDepositConfigModel {
 	public final String rarity;
 	public final boolean generateSamples;
 	public final List<SampleBlockDefinitionModel> sampleBlocks;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("protection", new Validator("protection").REQUIRES_INT);
+		validators.put("durability", new Validator("durability").REQUIRES_INT);
+	}
 
 	public GeodeDepositConfigModel(List<CommonBlockDefinitionModel> outerShellBlocks, List<CommonBlockDefinitionModel> innerShellBlocks, List<CommonBlockDefinitionModel> innerBlocks, List<CommonBlockDefinitionModel> fillBlocks, List<String> fillerTypes, List<String> clusters, int chance, double crackChance, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {
 		this.outerShellBlocks = outerShellBlocks;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/geode/GeodeDepositModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/geode/GeodeDepositModel.java
@@ -29,7 +29,7 @@ public class GeodeDepositModel extends CommonDepositModelBase {
 	}
 
 	public List<String> getFillerTypes() {
-		if (config.fillerTypes.isEmpty()) throw new IllegalArgumentException("Filler Types for " + name + " cannot be empty.");
+//		if (config.fillerTypes.isEmpty()) throw new IllegalArgumentException("Filler Types for " + name + " cannot be empty.");
 		return config.fillerTypes;
 	}
 
@@ -38,17 +38,17 @@ public class GeodeDepositModel extends CommonDepositModelBase {
 	}
 
 	public int getMaxYLevel() {
-		if (config.maxYLevel < -64 || config.maxYLevel > 320) throw new IllegalArgumentException("Max Y for " + name + " is out of Range [-64 - 320]");
+//		if (config.maxYLevel < -64 || config.maxYLevel > 320) throw new IllegalArgumentException("Max Y for " + name + " is out of Range [-64 - 320]");
 		return config.maxYLevel;
 	}
 
 	public int getMinYLevel() {
-		if (config.minYLevel < -64 || config.minYLevel > 320) throw new IllegalArgumentException("Min Y for " + name + " is out of Range [-64 - 320]");
+//		if (config.minYLevel < -64 || config.minYLevel > 320) throw new IllegalArgumentException("Min Y for " + name + " is out of Range [-64 - 320]");
 		return config.minYLevel;
 	}
 
 	public int getChance() {
-		if (config.chance < 1 || config.chance > 100) throw new IllegalArgumentException("Chance for " + name + " is out of Range [1 - 100]");
+//		if (config.chance < 1 || config.chance > 100) throw new IllegalArgumentException("Chance for " + name + " is out of Range [1 - 100]");
 		return config.chance;
 	}
 
@@ -57,38 +57,39 @@ public class GeodeDepositModel extends CommonDepositModelBase {
 	}
 
 	public double getCrackChance() {
-		if (config.crackChance < 0.0D || config.crackChance > 1.0D) throw new IllegalArgumentException("Crack Chance for " + name + " is out of Range [0.0 - 1.0]");
+//		if (config.crackChance < 0.0D || config.crackChance > 1.0D) throw new IllegalArgumentException("Crack Chance for " + name + " is out of Range [0.0 - 1.0]");
 		return config.crackChance;
 	}
 
 	public List<CommonBlockDefinitionModel> getOuterShellBlocks() {
-		if (config.outerShellBlocks.isEmpty()) throw new IllegalArgumentException("Outer Shell Blocks for " + name + " cannot be empty.");
+//		if (config.outerShellBlocks.isEmpty()) throw new IllegalArgumentException("Outer Shell Blocks for " + name + " cannot be empty.");
 		return config.outerShellBlocks;
 	}
 
 	public List<CommonBlockDefinitionModel> getInnerShellBlocks() {
-		if (config.innerShellBlocks.isEmpty()) throw new IllegalArgumentException("Inner Shell Blocks for " + name + " cannot be empty.");
+//		if (config.innerShellBlocks.isEmpty()) throw new IllegalArgumentException("Inner Shell Blocks for " + name + " cannot be empty.");
 		return config.innerShellBlocks;
 	}
 
 	public List<CommonBlockDefinitionModel> getInnerBlocks() {
-		if (config.innerBlocks.isEmpty()) throw new IllegalArgumentException("Inner Blocks for " + name + " cannot be empty.");
+//		if (config.innerBlocks.isEmpty()) throw new IllegalArgumentException("Inner Blocks for " + name + " cannot be empty.");
 		return config.innerBlocks;
 	}
 
 	public List<CommonBlockDefinitionModel> getFillBlocks() {
 		// TODO: Check to see if this can be empty
-		if (config.fillBlocks.isEmpty()) throw new IllegalArgumentException("Fill Blocks for " + name + " cannot be empty.");
+		// NOTE: Currently checked if not empty in the validation step. See #218 *Kanzaji
+//		if (config.fillBlocks.isEmpty()) throw new IllegalArgumentException("Fill Blocks for " + name + " cannot be empty.");
 		return config.fillBlocks;
 	}
 
 	public String getPlacement() {
-		if (!config.placement.equals("uniform") && !config.placement.equals("triangle")) throw new IllegalArgumentException("Placement for " + name + " is invalid.");
+//		if (!config.placement.equals("uniform") && !config.placement.equals("triangle")) throw new IllegalArgumentException("Placement for " + name + " is invalid.");
 		return config.placement;
 	}
 
 	public String getRarity() {
-		if (!config.rarity.equals("common") && !config.rarity.equals("rare")) throw new IllegalArgumentException("Rarity for " + name + " is invalid.");
+//		if (!config.rarity.equals("common") && !config.rarity.equals("rare")) throw new IllegalArgumentException("Rarity for " + name + " is invalid.");
 		return config.rarity;
 	}
 
@@ -97,7 +98,7 @@ public class GeodeDepositModel extends CommonDepositModelBase {
 	}
 
 	public List<SampleBlockDefinitionModel> getSampleBlocks() {
-		if (hasSamples() && config.sampleBlocks.isEmpty()) throw new IllegalArgumentException("Sample Blocks for " + name + " cannot be empty if generateSamples is set to true.");
+//		if (hasSamples() && config.sampleBlocks.isEmpty()) throw new IllegalArgumentException("Sample Blocks for " + name + " cannot be empty if generateSamples is set to true.");
 		return config.sampleBlocks;
 	}
 }

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sample/SampleBlockDefinitionModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sample/SampleBlockDefinitionModel.java
@@ -1,9 +1,20 @@
 package com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.DepositValidators;
+import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
+import org.jetbrains.annotations.Nullable;
 
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 public class SampleBlockDefinitionModel {
 	public static final Codec<SampleBlockDefinitionModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -19,7 +30,34 @@ public class SampleBlockDefinitionModel {
 	protected final int weight;
 	private final String strata;
 
-	public SampleBlockDefinitionModel(String block, String tag, String material, int weight, String strata) {
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("block", 	new Validator("block").getResourceIDValidation(false));
+		validators.put("tag", 		new Validator("tag").getResourceIDValidation(false));
+		validators.put("weight", 	new Validator("weight").REQUIRES_INT);
+		validators.put("material_rg", DepositValidators.getFullMaterialValidation(new Validator("material")));
+
+		Validator strataValidator = new Validator("strata");
+		validators.put("strata_rg", (element, path) -> {
+			if (!strataValidator.assertParentObject(element, path)) return false;
+			JsonObject parent = element.getAsJsonObject();
+			if (Objects.isNull(parent.get("material"))) {
+				Validator.LOGGER.warn(
+					"\"%s\" should not be present when specified sample is not material based in file \"%s\"."
+					.formatted(strataValidator.getName(), Validator.obfuscatePath(path))
+				);
+			}
+			return strataValidator.getRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry", false).apply(parent.get(strataValidator.getName()), path);
+		});
+	}
+
+	public SampleBlockDefinitionModel(@Nullable String block, @Nullable String tag, @Nullable String material, int weight, @Nullable String strata) {
 		this.block = block;
 		this.tag = tag;
 		this.weight = weight;
@@ -31,19 +69,19 @@ public class SampleBlockDefinitionModel {
 		return weight;
 	}
 
-	public String getBlock() {
+	public @Nullable String getBlock() {
 		return block;
 	}
 
-	public String getTag() {
+	public @Nullable String getTag() {
 		return tag;
 	}
 
-	public String getMaterial() {
+	public @Nullable String getMaterial() {
 		return material;
 	}
 
-	public String getStrata() {
+	public @Nullable String getStrata() {
 		return strata;
 	}
 }

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sample/SampleBlockDefinitionModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sample/SampleBlockDefinitionModel.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.Nullable;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
@@ -47,12 +46,14 @@ public class SampleBlockDefinitionModel {
 		validators.put("strata_rg", (element, path) -> {
 			if (!strataValidator.assertParentObject(element, path)) return false;
 			JsonObject parent = element.getAsJsonObject();
-			if (Objects.isNull(parent.get("material"))) {
-				Validator.LOGGER.warn(
-					"\"%s\" should not be present when specified sample is not material based in file \"%s\"."
-					.formatted(strataValidator.getName(), Validator.obfuscatePath(path))
-				);
-			}
+
+			if (Validator.isOtherFieldPresent("material", parent))
+				return strataValidator.getRequiredRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry", false).apply(parent.get(strataValidator.getName()), path);
+
+			Validator.LOGGER.warn(
+				"\"%s\" should not be present when specified sample is not material based in file \"%s\"."
+				.formatted(strataValidator.getName(), Validator.obfuscatePath(path))
+			);
 			return strataValidator.getRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry", false).apply(parent.get(strataValidator.getName()), path);
 		});
 	}

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sphere/SphereDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sphere/SphereDepositConfigModel.java
@@ -4,8 +4,10 @@ import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.DepositValidators;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
+import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
 
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -46,8 +48,16 @@ public class SphereDepositConfigModel {
 	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
 
 	static {
-		validators.put("protection", new Validator("protection").REQUIRES_INT);
-		validators.put("durability", new Validator("durability").REQUIRES_INT);
+		validators.put("blocks", 		new Validator("blocks").getRequiredObjectValidation(CommonBlockDefinitionModel.validators, true));
+		validators.put("fillerTypes", 	new Validator("fillerTypes").getRequiredRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry", true));
+		validators.put("chance", 		new Validator("chance").getRequiredIntRange(1, 100, false));
+		validators.put("radius", 		new Validator("radius").getRequiredIntRange(1, 16, false));
+		validators.put("minYLevel", 	new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
+		validators.put("maxYLevel_rg", 	DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
+		validators.put("placement", 	new Validator("placement").getAcceptsOnlyValidation(List.of("uniform", "triangle"), false));
+		validators.put("rarity", 		new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare"), false));
+		validators.put("generateSamples",new Validator("generateSamples").REQUIRES_BOOLEAN);
+		validators.put("sampleBlocks", 	new Validator("sampleBlocks").getObjectValidation(SampleBlockDefinitionModel.validators, true));
 	}
 
 	public SphereDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int radius, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sphere/SphereDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sphere/SphereDepositConfigModel.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
-import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.DepositValidators;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
@@ -53,11 +52,12 @@ public class SphereDepositConfigModel {
 		validators.put("chance", 		new Validator("chance").getRequiredIntRange(1, 100, false));
 		validators.put("radius", 		new Validator("radius").getRequiredIntRange(1, 16, false));
 		validators.put("minYLevel", 	new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
-		validators.put("maxYLevel_rg", 	DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
+		validators.put("maxYLevel_rg", 	new Validator("maxYLevel").getMaxYLevelValidation("minYLevel"));
 		validators.put("placement", 	new Validator("placement").getAcceptsOnlyValidation(List.of("uniform", "triangle"), false));
 		validators.put("rarity", 		new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare"), false));
 		validators.put("generateSamples",new Validator("generateSamples").REQUIRES_BOOLEAN);
-		validators.put("sampleBlocks", 	new Validator("sampleBlocks").getObjectValidation(SampleBlockDefinitionModel.validators, true));
+		Validator sampleValidator = new Validator("sampleBlocks");
+		validators.put("sampleBlocks_rg", sampleValidator.getIfOtherFieldSet("generateSamples", sampleValidator.getRequiredObjectValidation(SampleBlockDefinitionModel.validators, true)));
 	}
 
 	public SphereDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int radius, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sphere/SphereDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sphere/SphereDepositConfigModel.java
@@ -1,12 +1,17 @@
 package com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sphere;
 
+import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
 
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 public class SphereDepositConfigModel {
 	public static final Codec<SphereDepositConfigModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -32,6 +37,18 @@ public class SphereDepositConfigModel {
 	public final String rarity;
 	public final boolean generateSamples;
 	public final List<SampleBlockDefinitionModel> sampleBlocks;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("protection", new Validator("protection").REQUIRES_INT);
+		validators.put("durability", new Validator("durability").REQUIRES_INT);
+	}
 
 	public SphereDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int radius, int minYLevel, int maxYLevel, String placement, String rarity, boolean generateSamples, List<SampleBlockDefinitionModel> sampleBlocks) {
 		this.blocks = blocks;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sphere/SphereDepositModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/sphere/SphereDepositModel.java
@@ -29,7 +29,7 @@ public class SphereDepositModel extends CommonDepositModelBase {
 	}
 
 	public int getChance() {
-		if (config.chance < 1 || config.chance > 100) throw new IllegalArgumentException("Chance for " + name + " is out of Range [1 - 100]");
+//		if (config.chance < 1 || config.chance > 100) throw new IllegalArgumentException("Chance for " + name + " is out of Range [1 - 100]");
 		return config.chance;
 	}
 
@@ -38,37 +38,37 @@ public class SphereDepositModel extends CommonDepositModelBase {
 	}
 
 	public int getMaxYLevel() {
-		if (config.maxYLevel < -64 || config.maxYLevel > 320) throw new IllegalArgumentException("Max Y for " + name + " is out of Range [-64 - 320]");
+//		if (config.maxYLevel < -64 || config.maxYLevel > 320) throw new IllegalArgumentException("Max Y for " + name + " is out of Range [-64 - 320]");
 		return config.maxYLevel;
 	}
 
 	public int getMinYLevel() {
-		if (config.minYLevel < -64 || config.minYLevel > 320) throw new IllegalArgumentException("Min Y for " + name + " is out of Range [-64 - 320]");
+//		if (config.minYLevel < -64 || config.minYLevel > 320) throw new IllegalArgumentException("Min Y for " + name + " is out of Range [-64 - 320]");
 		return config.minYLevel;
 	}
 
 	public List<CommonBlockDefinitionModel> getBlocks() {
-		if (config.blocks.isEmpty()) throw new IllegalArgumentException("Blocks for " + name + " cannot be empty.");
+//		if (config.blocks.isEmpty()) throw new IllegalArgumentException("Blocks for " + name + " cannot be empty.");
 		return config.blocks;
 	}
 
 	public List<String> getFillerTypes() {
-		if (config.fillerTypes.isEmpty()) throw new IllegalArgumentException("Filler Types for " + name + " cannot be empty.");
+//		if (config.fillerTypes.isEmpty()) throw new IllegalArgumentException("Filler Types for " + name + " cannot be empty.");
 		return config.fillerTypes;
 	}
 
 	public int getRadius() {
-		if (config.radius < 1 || config.radius > 16) throw new IllegalArgumentException("Radius for " + name + " is out of Range [1 - 16]");
+//		if (config.radius < 1 || config.radius > 16) throw new IllegalArgumentException("Radius for " + name + " is out of Range [1 - 16]");
 		return config.radius;
 	}
 
 	public String getPlacement() {
-		if (!config.placement.equals("uniform") && !config.placement.equals("triangle")) throw new IllegalArgumentException("Placement for " + name + " is invalid.");
+//		if (!config.placement.equals("uniform") && !config.placement.equals("triangle")) throw new IllegalArgumentException("Placement for " + name + " is invalid.");
 		return config.placement;
 	}
 
 	public String getRarity() {
-		if (!config.rarity.equals("common") && !config.rarity.equals("rare")) throw new IllegalArgumentException("Rarity for " + name + " is invalid.");
+//		if (!config.rarity.equals("common") && !config.rarity.equals("rare")) throw new IllegalArgumentException("Rarity for " + name + " is invalid.");
 		return config.rarity;
 	}
 
@@ -77,7 +77,7 @@ public class SphereDepositModel extends CommonDepositModelBase {
 	}
 
 	public List<SampleBlockDefinitionModel> getSampleBlocks() {
-		if (hasSamples() && config.sampleBlocks.isEmpty()) throw new IllegalArgumentException("Sample Blocks for " + name + " cannot be empty if generateSamples is set to true.");
+//		if (hasSamples() && config.sampleBlocks.isEmpty()) throw new IllegalArgumentException("Sample Blocks for " + name + " cannot be empty if generateSamples is set to true.");
 		return config.sampleBlocks;
 	}
 }

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/test/TestDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/test/TestDepositConfigModel.java
@@ -28,7 +28,9 @@ import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.DepositValidators;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
+import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
 
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -61,8 +63,12 @@ public class TestDepositConfigModel {
 	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
 
 	static {
-		validators.put("protection", new Validator("protection").REQUIRES_INT);
-		validators.put("durability", new Validator("durability").REQUIRES_INT);
+		validators.put("blocks", 		new Validator("blocks").getRequiredObjectValidation(CommonBlockDefinitionModel.validators, true));
+		validators.put("fillerTypes", 	new Validator("fillerTypes").getRequiredRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry", true));
+		validators.put("chance", 		new Validator("chance").getRequiredIntRange(1, 100, false));
+		validators.put("size", 			new Validator("size").getRequiredIntRange(1, Integer.MAX_VALUE, false));
+		validators.put("minYLevel", 	new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
+		validators.put("maxYLevel_rg", 	DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
 	}
 
 	public TestDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/test/TestDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/test/TestDepositConfigModel.java
@@ -24,11 +24,17 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.deposit.model.test;
 
+import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 public class TestDepositConfigModel {
 	public static final Codec<TestDepositConfigModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -46,6 +52,18 @@ public class TestDepositConfigModel {
 	private final int size;
 	private final int minYLevel;
 	private final int maxYLevel;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("protection", new Validator("protection").REQUIRES_INT);
+		validators.put("durability", new Validator("durability").REQUIRES_INT);
+	}
 
 	public TestDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel) {
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/test/TestDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/test/TestDepositConfigModel.java
@@ -68,7 +68,7 @@ public class TestDepositConfigModel {
 		validators.put("chance", 		new Validator("chance").getRequiredIntRange(1, 100, false));
 		validators.put("size", 			new Validator("size").getRequiredIntRange(1, Integer.MAX_VALUE, false));
 		validators.put("minYLevel", 	new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
-		validators.put("maxYLevel_rg", 	DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
+		validators.put("maxYLevel_rg", 	new Validator("maxYLevel").getMaxYLevelValidation("minYLevel"));
 	}
 
 	public TestDepositConfigModel(List<CommonBlockDefinitionModel> blocks, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/vanilla/VanillaDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/vanilla/VanillaDepositConfigModel.java
@@ -1,12 +1,18 @@
 package com.ridanisaurus.emendatusenigmatica.loader.deposit.model.vanilla;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Optional;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.BiFunction;
+
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
 
 public class VanillaDepositConfigModel {
 	public static final Codec<VanillaDepositConfigModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -31,7 +37,71 @@ public class VanillaDepositConfigModel {
 	public final String placement;
 	public final String rarity;
 
-	public VanillaDepositConfigModel(String block, String material, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel, String placement, String rarity) {
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("fillerTypes", new Validator("fillerTypes").getRequiredRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry"));
+		validators.put("chance", new Validator("chance").getRequiredIntRange(1, 100));
+		validators.put("size", new Validator("size").getRequiredIntRange(1, 16));
+		validators.put("minYLevel", new Validator("minYLevel").getRequiredIntRange(-64, 320));
+		validators.put("placement", new Validator("placement").getAcceptsOnlyValidation(List.of("uniform, triangle")));
+		validators.put("rarity", new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare")));
+		validators.put("block", new Validator("block").RESOURCE_ID);
+
+		Validator maxYValidator = new Validator("maxYLevel");
+		validators.put(maxYValidator.getName() + "_rg", (element, path) -> {
+			if (!maxYValidator.assertParentObject(element, path)) return false;
+			JsonObject parent = element.getAsJsonObject();
+			JsonElement value = parent.get(maxYValidator.getName());
+			JsonElement min = parent.get("minYLevel");
+			int minValue = -64;
+
+			if (!maxYValidator.REQUIRED.apply(value, path)) return false;
+
+			if (Objects.isNull(min)) {
+				LOGGER.warn("Field \"minYLevel\" is missing! Can't accurately verify \"%s\" in file \"%s\".".formatted(maxYValidator.getName(), Validator.obfuscatePath(path)));
+			} else {
+				try {
+					if (!min.isJsonPrimitive()) throw new ClassCastException();
+					minValue = min.getAsInt();
+					if (minValue > 320) {
+						LOGGER.error("Min value is above max 320! Can't accurately verify \"%s\" in file \"%s\".".formatted(maxYValidator.getName(), Validator.obfuscatePath(path)));
+						minValue = -64;
+					}
+				} catch (ClassCastException e) {
+					LOGGER.error("Field \"minYLevel\" requires a Numeric value! Can't accurately verify \"%s\" in file \"%s\".".formatted(maxYValidator.getName(), Validator.obfuscatePath(path)));
+				}
+			}
+
+			return maxYValidator.getIntRange(minValue, 320).apply(value, path);
+		});
+
+		Validator materialValidator = new Validator("material");
+		// TODO: both Block + Material, error or warning?
+
+		validators.put("material_rg", (element, path) -> {
+			if (!materialValidator.assertParentObject(element, path)) return false;
+			JsonObject parent = element.getAsJsonObject();
+			JsonElement blockElement = parent.get("block");
+			JsonElement materialElement = parent.get(materialValidator.getName());
+			if (Objects.isNull(blockElement) && Objects.isNull(materialElement)) {
+				LOGGER.error("Either \"%s\" or \"%s\" is required to be present in the file \"%s\".".formatted("block", materialValidator.getName() , Validator.obfuscatePath(path)));
+				return false;
+			}
+			if (Objects.nonNull(blockElement) && Objects.nonNull(materialElement)) {
+				LOGGER.error("Only \"%s\" or \"%s\" can be present in the file \"%s\".".formatted("block", materialValidator.getName() , Validator.obfuscatePath(path)));
+				return false;
+			}
+			return true;
+		});
+	}
+
+	public VanillaDepositConfigModel(@Nullable String block, @Nullable String material, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel, String placement, String rarity) {
 		this.block = block;
 		this.material = material;
 		this.fillerTypes = fillerTypes;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/vanilla/VanillaDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/vanilla/VanillaDepositConfigModel.java
@@ -1,18 +1,19 @@
 package com.ridanisaurus.emendatusenigmatica.loader.deposit.model.vanilla;
 
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.DepositValidators;
 import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
-
-import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
 
 public class VanillaDepositConfigModel {
 	public static final Codec<VanillaDepositConfigModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -45,60 +46,15 @@ public class VanillaDepositConfigModel {
 	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
 
 	static {
-		validators.put("fillerTypes", new Validator("fillerTypes").getRequiredRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry"));
-		validators.put("chance", new Validator("chance").getRequiredIntRange(1, 100));
-		validators.put("size", new Validator("size").getRequiredIntRange(1, 16));
-		validators.put("minYLevel", new Validator("minYLevel").getRequiredIntRange(-64, 320));
-		validators.put("placement", new Validator("placement").getAcceptsOnlyValidation(List.of("uniform, triangle")));
-		validators.put("rarity", new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare")));
-		validators.put("block", new Validator("block").RESOURCE_ID);
-
-		Validator maxYValidator = new Validator("maxYLevel");
-		validators.put(maxYValidator.getName() + "_rg", (element, path) -> {
-			if (!maxYValidator.assertParentObject(element, path)) return false;
-			JsonObject parent = element.getAsJsonObject();
-			JsonElement value = parent.get(maxYValidator.getName());
-			JsonElement min = parent.get("minYLevel");
-			int minValue = -64;
-
-			if (!maxYValidator.REQUIRED.apply(value, path)) return false;
-
-			if (Objects.isNull(min)) {
-				LOGGER.warn("Field \"minYLevel\" is missing! Can't accurately verify \"%s\" in file \"%s\".".formatted(maxYValidator.getName(), Validator.obfuscatePath(path)));
-			} else {
-				try {
-					if (!min.isJsonPrimitive()) throw new ClassCastException();
-					minValue = min.getAsInt();
-					if (minValue > 320) {
-						LOGGER.error("Min value is above max 320! Can't accurately verify \"%s\" in file \"%s\".".formatted(maxYValidator.getName(), Validator.obfuscatePath(path)));
-						minValue = -64;
-					}
-				} catch (ClassCastException e) {
-					LOGGER.error("Field \"minYLevel\" requires a Numeric value! Can't accurately verify \"%s\" in file \"%s\".".formatted(maxYValidator.getName(), Validator.obfuscatePath(path)));
-				}
-			}
-
-			return maxYValidator.getIntRange(minValue, 320).apply(value, path);
-		});
-
-		Validator materialValidator = new Validator("material");
-		// TODO: both Block + Material, error or warning?
-
-		validators.put("material_rg", (element, path) -> {
-			if (!materialValidator.assertParentObject(element, path)) return false;
-			JsonObject parent = element.getAsJsonObject();
-			JsonElement blockElement = parent.get("block");
-			JsonElement materialElement = parent.get(materialValidator.getName());
-			if (Objects.isNull(blockElement) && Objects.isNull(materialElement)) {
-				LOGGER.error("Either \"%s\" or \"%s\" is required to be present in the file \"%s\".".formatted("block", materialValidator.getName() , Validator.obfuscatePath(path)));
-				return false;
-			}
-			if (Objects.nonNull(blockElement) && Objects.nonNull(materialElement)) {
-				LOGGER.error("Only \"%s\" or \"%s\" can be present in the file \"%s\".".formatted("block", materialValidator.getName() , Validator.obfuscatePath(path)));
-				return false;
-			}
-			return true;
-		});
+		validators.put("material_rg",	DepositValidators.getBlockMaterialValidation(new Validator("material")));
+		validators.put("block", 		new Validator("block").getResourceIDValidation(false));
+		validators.put("fillerTypes", 	new Validator("fillerTypes").getRequiredRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry", true));
+		validators.put("chance", 		new Validator("chance").getRequiredIntRange(1, 100, false));
+		validators.put("size", 			new Validator("size").getRequiredIntRange(1, 16, false));
+		validators.put("minYLevel", 	new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
+		validators.put("maxYLevel_rg", 	DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
+		validators.put("placement", 	new Validator("placement").getAcceptsOnlyValidation(List.of("uniform", "triangle"), false));
+		validators.put("rarity", 		new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare"), false));
 	}
 
 	public VanillaDepositConfigModel(@Nullable String block, @Nullable String material, List<String> fillerTypes, int chance, int size, int minYLevel, int maxYLevel, String placement, String rarity) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/vanilla/VanillaDepositConfigModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/vanilla/VanillaDepositConfigModel.java
@@ -52,7 +52,7 @@ public class VanillaDepositConfigModel {
 		validators.put("chance", 		new Validator("chance").getRequiredIntRange(1, 100, false));
 		validators.put("size", 			new Validator("size").getRequiredIntRange(1, 16, false));
 		validators.put("minYLevel", 	new Validator("minYLevel").getRequiredIntRange(-64, 320, false));
-		validators.put("maxYLevel_rg", 	DepositValidators.getMaxYLevelValidation(new Validator("maxYLevel"), "minYLevel"));
+		validators.put("maxYLevel_rg", 	new Validator("maxYLevel").getMaxYLevelValidation("minYLevel"));
 		validators.put("placement", 	new Validator("placement").getAcceptsOnlyValidation(List.of("uniform", "triangle"), false));
 		validators.put("rarity", 		new Validator("rarity").getAcceptsOnlyValidation(List.of("common", "rare"), false));
 	}

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/vanilla/VanillaDepositModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/model/vanilla/VanillaDepositModel.java
@@ -3,7 +3,6 @@ package com.ridanisaurus.emendatusenigmatica.loader.deposit.model.vanilla;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonDepositModelBase;
-import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sample.SampleBlockDefinitionModel;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -17,7 +16,7 @@ public class VanillaDepositModel extends CommonDepositModelBase {
 			VanillaDepositConfigModel.CODEC.fieldOf("config").forGetter(it -> it.config)
 	).apply(x, VanillaDepositModel::new));
 
-	private VanillaDepositConfigModel config;
+	private final VanillaDepositConfigModel config;
 
 	public VanillaDepositModel(String type, String dimension, List<String> biomes, String name, VanillaDepositConfigModel config) {
 		super(type, dimension, biomes, name);
@@ -29,27 +28,27 @@ public class VanillaDepositModel extends CommonDepositModelBase {
 	}
 
 	public int getMinYLevel() {
-		if (config.minYLevel < -64 || config.minYLevel > 320) throw new IllegalArgumentException("Min Y for " + name + " is out of Range [-64 - 320]");
+//		if (config.minYLevel < -64 || config.minYLevel > 320) throw new IllegalArgumentException("Min Y for " + name + " is out of Range [-64 - 320]");
 		return config.minYLevel;
 	}
 
 	public int getMaxYLevel() {
-		if (config.maxYLevel < -64 || config.maxYLevel > 320) throw new IllegalArgumentException("Max Y for " + name + " is out of Range [-64 - 320]");
+//		if (config.maxYLevel < -64 || config.maxYLevel > 320) throw new IllegalArgumentException("Max Y for " + name + " is out of Range [-64 - 320]");
 		return config.maxYLevel;
 	}
 
 	public String getPlacement() {
-		if (!config.placement.equals("uniform") && !config.placement.equals("triangle")) throw new IllegalArgumentException("Placement for " + name + " contains an invalid option.");
+//		if (!config.placement.equals("uniform") && !config.placement.equals("triangle")) throw new IllegalArgumentException("Placement for " + name + " contains an invalid option.");
 		return config.placement;
 	}
 
 	public String getRarity() {
-		if (!config.rarity.equals("common") && !config.rarity.equals("rare")) throw new IllegalArgumentException("Rarity for " + name + " contains an invalid option.");
+//		if (!config.rarity.equals("common") && !config.rarity.equals("rare")) throw new IllegalArgumentException("Rarity for " + name + " contains an invalid option.");
 		return config.rarity;
 	}
 
 	public int getChance() {
-		if (config.chance < 1 || config.chance > 100) throw new IllegalArgumentException("Chance for " + name + " is out of Range [1 - 100]");
+//		if (config.chance < 1 || config.chance > 100) throw new IllegalArgumentException("Chance for " + name + " is out of Range [1 - 100]");
 		return config.chance;
 	}
 
@@ -58,12 +57,12 @@ public class VanillaDepositModel extends CommonDepositModelBase {
 	}
 
 	public int getSize() {
-		if (config.size < 1 || config.size > 16) throw new IllegalArgumentException("Size for " + name + " is out of Range [1 - 16]");
+//		if (config.size < 1 || config.size > 16) throw new IllegalArgumentException("Size for " + name + " is out of Range [1 - 16]");
 		return config.size;
 	}
 
 	public List<String> getFillerTypes() {
-		if (config.fillerTypes.isEmpty()) throw new IllegalArgumentException("Filler Types for " + name + " cannot be empty.");
+//		if (config.fillerTypes.isEmpty()) throw new IllegalArgumentException("Filler Types for " + name + " cannot be empty.");
 		return config.fillerTypes;
 	}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/DenseDepositProcessor.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/DenseDepositProcessor.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 public class DenseDepositProcessor implements IDepositProcessor {
 
-	private JsonObject object;
+	private final JsonObject object;
 	private DenseDepositModel model;
 
 	public DenseDepositProcessor(JsonObject object) {
@@ -24,9 +24,7 @@ public class DenseDepositProcessor implements IDepositProcessor {
 	@Override
 	public void load() {
 		Optional<Pair<DenseDepositModel, JsonElement>> result = JsonOps.INSTANCE.withDecoder(DenseDepositModel.CODEC).apply(object).result();
-		if (!result.isPresent()) {
-			return;
-		}
+		if (result.isEmpty()) return;
 		model = result.get().getFirst();
 	}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/DikeDepositProcessor.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/DikeDepositProcessor.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 public class DikeDepositProcessor implements IDepositProcessor {
 
-	private JsonObject object;
+	private final JsonObject object;
 	private DikeDepositModel model;
 
 	public DikeDepositProcessor(JsonObject object) {
@@ -24,9 +24,7 @@ public class DikeDepositProcessor implements IDepositProcessor {
 	@Override
 	public void load() {
 		Optional<Pair<DikeDepositModel, JsonElement>> result = JsonOps.INSTANCE.withDecoder(DikeDepositModel.CODEC).apply(object).result();
-		if (!result.isPresent()) {
-			return;
-		}
+		if (result.isEmpty()) return;
 		model = result.get().getFirst();
 	}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/GeodeDepositProcessor.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/GeodeDepositProcessor.java
@@ -26,9 +26,7 @@ public class GeodeDepositProcessor implements IDepositProcessor {
 	@Override
 	public void load() {
 		Optional<Pair<GeodeDepositModel, JsonElement>> result = JsonOps.INSTANCE.withDecoder(GeodeDepositModel.CODEC).apply(object).result();
-		if (!result.isPresent()) {
-			return;
-		}
+		if (result.isEmpty()) return;
 		model = result.get().getFirst();
 	}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/SphereDepositProcessor.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/SphereDepositProcessor.java
@@ -7,7 +7,6 @@ import com.mojang.serialization.JsonOps;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.IDepositProcessor;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonBlockDefinitionModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.common.CommonDepositModelBase;
-import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sphere.SphereDepositConfigModel;
 import com.ridanisaurus.emendatusenigmatica.loader.deposit.model.sphere.SphereDepositModel;
 
 import java.util.List;
@@ -15,7 +14,7 @@ import java.util.Optional;
 
 public class SphereDepositProcessor implements IDepositProcessor {
 
-	private JsonObject object;
+	private final JsonObject object;
 	private SphereDepositModel model;
 
 	public SphereDepositProcessor(JsonObject object) {
@@ -25,9 +24,7 @@ public class SphereDepositProcessor implements IDepositProcessor {
 	@Override
 	public void load() {
 		Optional<Pair<SphereDepositModel, JsonElement>> result = JsonOps.INSTANCE.withDecoder(SphereDepositModel.CODEC).apply(object).result();
-		if (!result.isPresent()) {
-			return;
-		}
+		if (result.isEmpty()) return;
 		model = result.get().getFirst();
 	}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/TestDepositProcessor.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/TestDepositProcessor.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 public class TestDepositProcessor implements IDepositProcessor {
 
-	private JsonObject object;
+	private final JsonObject object;
 	private TestDepositModel model;
 
 	public TestDepositProcessor(JsonObject object) {
@@ -24,9 +24,7 @@ public class TestDepositProcessor implements IDepositProcessor {
 	@Override
 	public void load() {
 		Optional<Pair<TestDepositModel, JsonElement>> result = JsonOps.INSTANCE.withDecoder(TestDepositModel.CODEC).apply(object).result();
-		if (!result.isPresent()) {
-			return;
-		}
+		if (result.isEmpty()) return;
 		model = result.get().getFirst();
 	}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/VanillaDepositProcessor.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/deposit/processsors/VanillaDepositProcessor.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 public class VanillaDepositProcessor implements IDepositProcessor {
 
-    private JsonObject object;
+    private final JsonObject object;
     private VanillaDepositModel model;
 
     public VanillaDepositProcessor(JsonObject object) {
@@ -24,9 +24,7 @@ public class VanillaDepositProcessor implements IDepositProcessor {
     @Override
     public void load() {
         Optional<Pair<VanillaDepositModel, JsonElement>> result = JsonOps.INSTANCE.withDecoder(VanillaDepositModel.CODEC).apply(object).result();
-        if (!result.isPresent()) {
-            return;
-        }
+        if (result.isEmpty()) return;
         model = result.get().getFirst();
     }
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/ArmorModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/ArmorModel.java
@@ -24,10 +24,16 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.parser.model;
 
+import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 public class ArmorModel {
 	public static final Codec<ArmorModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -40,6 +46,18 @@ public class ArmorModel {
 
 	private final int protection;
 	private final int durability;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("protection", new Validator("protection").REQUIRES_INT);
+		validators.put("durability", new Validator("durability").REQUIRES_INT);
+	}
 
 	public ArmorModel(int protection, int durability) {
 		this.protection = protection;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/CompatModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/CompatModel.java
@@ -276,7 +276,7 @@ public class CompatModel {
 					});
 				}
 
-				return outputValidator.getObjectValidation(CompatIOModel.validators).apply(element.get("input"), path);
+				return outputValidator.getObjectValidation(CompatIOModel.validators).apply(element.get("output"), path);
 			});
 
 			validators.put("output", outputValidator.getObjectValidation(CompatIOModel.validators));

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/CompatModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/CompatModel.java
@@ -53,7 +53,7 @@ public class CompatModel {
 	 */
 	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
 	static {
-		validators.put("id", new Validator("id").getRegisteredIDValidation(DefaultConfigPlugin.MATERIAL_IDS, "Material Registry", false));
+		validators.put("id", new Validator("id").getRequiredRegisteredIDValidation(DefaultConfigPlugin.MATERIAL_IDS, "Material Registry", false));
 		validators.put("recipes", new Validator("recipes").getRequiredObjectValidation(CompatRecipesModel.validators));
 	}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/CompatModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/CompatModel.java
@@ -54,7 +54,7 @@ public class CompatModel {
 	 * Holds verifying functions for each field.
 	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
 	 */
-	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new HashMap<>();
+	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new LinkedHashMap<>();
 	static {
 		Validator idValidator = new Validator("id");
 		verifiers.put("id", (element, path) -> {
@@ -64,11 +64,11 @@ public class CompatModel {
 			try {
 				String value = element.getAsString();
 				if (!DefaultConfigPlugin.MATERIAL_IDS.contains(value)) {
-					if (log) LOGGER.error("Material id (%s) is not registered. Found in file \"%s\".".formatted(value, Validator.obfuscatePath(path)));
+					if (log) LOGGER.error("Material id (\"%s\") is not registered. Found in file \"%s\".".formatted(value, Validator.obfuscatePath(path)));
 					return false;
 				}
 			} catch (ClassCastException ignored) {} catch (Exception e) {
-				if (log) LOGGER.error("Caught exception while reading values for id in \"%s\" file.".formatted(Validator.obfuscatePath(path)));
+				if (log) LOGGER.error("Caught exception while reading values for \"id\" in \"%s\" file.".formatted(Validator.obfuscatePath(path)));
 				return false;
 			}
 
@@ -111,7 +111,7 @@ public class CompatModel {
 		 * Function returns true if verification was successful, false otherwise to stop registration of the json.
 		 * Adding suffix _rg will request the original object instead of just the value of the field.
 		 */
-		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new HashMap<>();
+		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new LinkedHashMap<>();
 		/**
 		 * Holds all acceptable mods and validators for their machines for the CompatModel.
 		 * @apiNote To add support for additional mod + machines, add an entry to this map with mod name and validator of the machine.
@@ -158,7 +158,7 @@ public class CompatModel {
 				try {
 					temp.add("machine", new JsonPrimitive(Objects.requireNonNull(element.get("machine")).getAsString()));
 				} catch (ClassCastException | NullPointerException e) {
-					temp.add("mod", new JsonPrimitive("NONE"));
+					temp.add("machine", new JsonPrimitive("NONE"));
 				}
 
 				array.forEach(entry -> {
@@ -247,7 +247,7 @@ public class CompatModel {
 		 * Function returns true if verification was successful, false otherwise to stop registration of the json.
 		 * Adding suffix _rg will request the original object instead of just the value of the field.
 		 */
-		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new HashMap<>();
+		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new LinkedHashMap<>();
 		static {
 			//TODO: Add "Accept_only_x_values" validator here
 			// All values here have _rg due to getting entire object of CompatRecipeModel.
@@ -352,11 +352,10 @@ public class CompatModel {
 		 * Function returns true if verification was successful, false otherwise to stop registration of the json.
 		 * Adding suffix _rg will request the original object instead of just the value of the field.
 		 */
-		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new HashMap<>();
+		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new LinkedHashMap<>();
 		static {
 			verifiers.put("item", new Validator("item").NON_EMPTY);
-			//TODO: Get real ranges, I'm guessing 64 and 1 is max here, but not sure
-			verifiers.put("count", new Validator("count").getRange(0, 64));
+			verifiers.put("count", new Validator("count").getIntRange(0, 64));
 			verifiers.put("chance", new Validator("chance").getRange(0, 1));
 		}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/CompatModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/CompatModel.java
@@ -24,20 +24,58 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.parser.model;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
-import java.util.List;
-import java.util.Optional;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
 
 public class CompatModel {
 	public static final Codec<CompatModel> CODEC = RecordCodecBuilder.create(x -> x.group(
 			Codec.STRING.fieldOf("id").forGetter(i -> i.id),
 			Codec.list(CompatRecipesModel.CODEC).fieldOf("recipes").forGetter(i -> i.recipes)
 	).apply(x, CompatModel::new));
-
 	private final String id;
 	private final List<CompatRecipesModel> recipes;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 */
+	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new HashMap<>();
+	static {
+		Validator idValidator = new Validator("id");
+		verifiers.put("id", (element, path) -> {
+			if (!idValidator.NON_EMPTY_REQUIRED.apply(element, path)) return false;
+			if (!idValidator.assertNotArray(element, path)) return false;
+
+			try {
+				String value = element.getAsString();
+				if (!DefaultConfigPlugin.MATERIAL_IDS.contains(value)) {
+					if (log) LOGGER.error("Material id (%s) is not registered. Found in file \"%s\".".formatted(value, Validator.obfuscatePath(path)));
+					return false;
+				}
+			} catch (ClassCastException ignored) {} catch (Exception e) {
+				if (log) LOGGER.error("Caught exception while reading values for id in \"%s\" file.".formatted(Validator.obfuscatePath(path)));
+				return false;
+			}
+
+			return true;
+		});
+		verifiers.put("recipes", new Validator("recipes").getRequiredObjectValidation(CompatRecipesModel.verifiers));
+	}
 
 	public CompatModel(String id, List<CompatRecipesModel> recipes) {
 		this.id = id;
@@ -57,8 +95,6 @@ public class CompatModel {
 		return recipes;
 	}
 
-
-
 	public static class CompatRecipesModel {
 		public static final Codec<CompatRecipesModel> CODEC = RecordCodecBuilder.create(x -> x.group(
 				Codec.STRING.fieldOf("mod").forGetter(i -> i.mod),
@@ -69,6 +105,97 @@ public class CompatModel {
 		private final String mod;
 		private final String machine;
 		private final List<CompatValuesModel> values;
+
+		/**
+		 * Holds verifying functions for each field.
+		 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+		 * Adding suffix _rg will request the original object instead of just the value of the field.
+		 */
+		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new HashMap<>();
+		/**
+		 * Holds all acceptable mods and validators for their machines for the CompatModel.
+		 * @apiNote To add support for additional mod + machines, add an entry to this map with mod name and validator of the machine.
+		 * @see CompatRecipesModel#acceptableMods
+		 * @see CompatRecipesModel#acceptableModIds
+		 * @see CompatValuesModel#acceptableMods
+		 */
+		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> acceptableMods = new HashMap<>();
+
+		/**
+		 * Holds all acceptable mods for mod validator.
+		 * @see CompatRecipesModel#acceptableMods
+		 * @see CompatRecipesModel#acceptableModIds
+		 * @see CompatValuesModel#acceptableMods
+		 */
+		public static final List<String> acceptableModIds = new ArrayList<>();
+		static {
+
+			Validator machineValidator = new Validator("machine");
+			acceptableMods.put("thermal", machineValidator.getRequiredAcceptsOnlyValidation(List.of("pulverizer", "induction_smelter")));
+			acceptableMods.put("create", machineValidator.getRequiredAcceptsOnlyValidation(List.of("crushing_wheels", "fan_washing")));
+			acceptableModIds.addAll(acceptableMods.keySet());
+
+			verifiers.put("mod", new Validator("mod").getRequiredAcceptsOnlyValidation(acceptableModIds));
+
+			Validator valuesValidator = new Validator("values");
+			verifiers.put("values_rg", (element_rg, path_rg) -> {
+				if (!(
+					valuesValidator.assertObject(element_rg, path_rg) &&
+					valuesValidator.assertArray(element_rg.getAsJsonObject().get("values"), path_rg)
+				)) return false;
+
+				AtomicBoolean validation = new AtomicBoolean(true);
+				JsonObject element = element_rg.getAsJsonObject();
+				JsonArray array = element.get("values").getAsJsonArray();
+
+				JsonObject temp = new JsonObject();
+				try {
+					temp.add("mod", new JsonPrimitive(Objects.requireNonNull(element.get("mod")).getAsString()));
+				} catch (ClassCastException | NullPointerException e) {
+					temp.add("mod", new JsonPrimitive("NONE"));
+				}
+
+				try {
+					temp.add("machine", new JsonPrimitive(Objects.requireNonNull(element.get("machine")).getAsString()));
+				} catch (ClassCastException | NullPointerException e) {
+					temp.add("mod", new JsonPrimitive("NONE"));
+				}
+
+				array.forEach(entry -> {
+					if (!valuesValidator.assertNotArray(entry, path_rg) || !valuesValidator.assertObject(entry, path_rg)) {
+						validation.set(false);
+						return;
+					}
+					if (Objects.nonNull(entry.getAsJsonObject().get("TEMP"))) LOGGER.warn("Unknown key TEMP found in file \"%s\".".formatted(Validator.obfuscatePath(path_rg)));
+					entry.getAsJsonObject().add("TEMP", temp);
+				});
+				return valuesValidator.validateObject(array, path_rg, CompatValuesModel.verifiers) && validation.get();
+			});
+
+			verifiers.put("machine_rg", (element, path) -> {
+				if (!machineValidator.assertObject(element, path)) return false;
+				if (!machineValidator.REQUIRED.apply(element.getAsJsonObject().get("machine"), path)) return false;
+
+				JsonElement modJson = element.getAsJsonObject().get("mod");
+				if (Objects.isNull(modJson)) {
+					LOGGER.error("Mod is null! Can't verify values of machine for \"%s\"".formatted(Validator.obfuscatePath(path)));
+					return false;
+				}
+
+				try {
+					String mod = modJson.getAsString();
+					var validator = acceptableMods.get(mod);
+					if (Objects.isNull(validator)) {
+						if (log) LOGGER.error("Illegal value for mod present! Can't verify values of machine for \"%s\"".formatted(Validator.obfuscatePath(path)));
+						return false;
+					}
+					return validator.apply(element.getAsJsonObject().get("machine"), path);
+				} catch (ClassCastException e) {
+					if (log) LOGGER.error("Mod is not a string! Can't verify values of machine for \"%s\".".formatted(Validator.obfuscatePath(path)));
+				}
+				return false;
+			});
+		}
 
 		public CompatRecipesModel(String mod, String machine, List<CompatValuesModel> values) {
 			this.mod = mod;
@@ -106,6 +233,90 @@ public class CompatModel {
 		private final List<CompatIOModel> input;
 		private final List<CompatIOModel> output;
 
+		/**
+		 * Holds all acceptable mods and validators for their machines for the CompatModel.
+		 * @apiNote To add support for additional mod + machines, add an entry to this map with mod name and validator of the machine.
+		 * @see CompatRecipesModel#acceptableMods
+		 * @see CompatRecipesModel#acceptableModIds
+		 * @see CompatValuesModel#acceptableMods
+		 */
+		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> acceptableMods = new HashMap<>();
+
+		/**
+		 * Holds verifying functions for each field.
+		 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+		 * Adding suffix _rg will request the original object instead of just the value of the field.
+		 */
+		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new HashMap<>();
+		static {
+			//TODO: Add "Accept_only_x_values" validator here
+			// All values here have _rg due to getting entire object of CompatRecipeModel.
+			// Those fields don't exists in that object.
+			Validator typeValidator = new Validator("type");
+			Validator inputValidator = new Validator("input");
+			Validator outputValidator = new Validator("output");
+
+			acceptableMods.put("thermal", typeValidator.getRequiredAcceptsOnlyValidation(List.of("ore", "raw", "alloy")));
+			acceptableMods.put("create", typeValidator.getRequiredAcceptsOnlyValidation(List.of("ore", "crushed_ore")));
+
+			// This is here to not spam the log with false warnings about a temporary memory-only field.
+			// Checking if this field is actually in the file is done above.
+			verifiers.put("TEMP", Validator.ALL);
+
+			verifiers.put("type_rg", (element, path) -> {
+				if (!typeValidator.assertObject(element, path)) return false;
+
+				String mod = element.getAsJsonObject().get("TEMP").getAsJsonObject().get("mod").getAsString();
+				if (mod.equals("NONE")) {
+					LOGGER.error("Mod is none! Can't verify values of type for \"%s\"".formatted(Validator.obfuscatePath(path)));
+					return false;
+				}
+
+				var validator = acceptableMods.get(mod);
+				if (Objects.isNull(validator)) {
+					if (log) LOGGER.error("Illegal value for mod present! Can't verify values of type for \"%s\"".formatted(Validator.obfuscatePath(path)));
+					return false;
+				}
+				return validator.apply(element.getAsJsonObject().get("type"), path);
+			});
+
+			verifiers.put("input_rg", (element_rg, path) -> {
+				if (!inputValidator.assertObject(element_rg, path)) return false;
+
+				JsonObject element = element_rg.getAsJsonObject();
+				if (Objects.isNull(element.get("input"))) return true;
+
+				JsonObject temp = element.get("TEMP").getAsJsonObject();
+				String mod = temp.get("mod").getAsString();
+				String machine = temp.get("machine").getAsString();
+				String type = "NONE";
+
+				if (log && mod.equals("NONE")) LOGGER.warn("Mod is none! Can't accurately verify values of input for \"%s\"".formatted(Validator.obfuscatePath(path)));
+				if (log && machine.equals("NONE")) LOGGER.warn("Machine is none! Can't accurately verify values of input for \"%s\"".formatted(Validator.obfuscatePath(path)));
+
+				try {
+					type = element.get("type").getAsString();
+				} catch (ClassCastException e) {
+					if (log) LOGGER.error("Type is not a string! Can't accurately verify values of input for \"%s\".".formatted(Validator.obfuscatePath(path)));
+				} catch (NullPointerException e) {
+					if (log) LOGGER.warn("Type is null! Can't accurately verify values of input for \"%s\"".formatted(Validator.obfuscatePath(path)));
+				}
+
+
+				if (log && !mod.equals("thermal")) LOGGER.warn("Input should not be present when selected mod is different than thermal (Currently: %s). Found in file \"%s\".".formatted(mod, Validator.obfuscatePath(path)));
+				if (log && !machine.equals("induction_smelter")) LOGGER.warn("Input should not be present when selected machine is different than induction_smelter (Currently: %s). Found in file \"%s\".".formatted(machine, Validator.obfuscatePath(path)));
+				if (log && !type.equals("alloy")) LOGGER.warn("Input should not be present when selected type is different than alloy (Currently: %s). Found in file \"%s\".".formatted(type, Validator.obfuscatePath(path)));
+
+				if (log) element.get("input").getAsJsonArray().forEach(entry -> {
+					if (Objects.nonNull(entry.getAsJsonObject().get("chance"))) LOGGER.warn("Chance should not be present in input object! Found in file \"%s\".".formatted(Validator.obfuscatePath(path)));
+				});
+
+				return outputValidator.getObjectValidation(CompatIOModel.verifiers).apply(element.get("input"), path);
+			});
+
+			verifiers.put("output", outputValidator.getObjectValidation(CompatIOModel.verifiers));
+		}
+
 		CompatValuesModel(String type, List<CompatIOModel> input, List<CompatIOModel> output) {
 			this.type = type;
 			this.input = input;
@@ -135,6 +346,19 @@ public class CompatModel {
 				count.orElse(0),
 				chance.orElse(0.0f)
 		)));
+
+		/**
+		 * Holds verifying functions for each field.
+		 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+		 * Adding suffix _rg will request the original object instead of just the value of the field.
+		 */
+		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new HashMap<>();
+		static {
+			verifiers.put("item", new Validator("item").NON_EMPTY);
+			//TODO: Get real ranges, I'm guessing 64 and 1 is max here, but not sure
+			verifiers.put("count", new Validator("count").getRange(0, 64));
+			verifiers.put("chance", new Validator("chance").getRange(0, 1));
+		}
 
 		private final String item;
 		private final int count;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/CompatModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/CompatModel.java
@@ -54,7 +54,7 @@ public class CompatModel {
 	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
 	static {
 		validators.put("id", new Validator("id").getRequiredRegisteredIDValidation(DefaultConfigPlugin.MATERIAL_IDS, "Material Registry", false));
-		validators.put("recipes", new Validator("recipes").getRequiredObjectValidation(CompatRecipesModel.validators));
+		validators.put("recipes", new Validator("recipes").getRequiredObjectValidation(CompatRecipesModel.validators, true));
 	}
 
 	public CompatModel(String id, List<CompatRecipesModel> recipes) {
@@ -248,6 +248,7 @@ public class CompatModel {
 				if (!inputValidator.assertParentObject(element_rg, path)) return false;
 
 				JsonObject element = element_rg.getAsJsonObject();
+				//TODO: Should this be required when the material is alloy -> Mod Thermal -> Machine Induction Smelter?
 				if (Objects.isNull(element.get("input"))) return true;
 				if (LOGGER.shouldLog) {
 					JsonObject temp = element.get("TEMP").getAsJsonObject();
@@ -276,10 +277,10 @@ public class CompatModel {
 					});
 				}
 
-				return outputValidator.getObjectValidation(CompatIOModel.validators).apply(element.get("output"), path);
+				return inputValidator.getObjectValidation(CompatIOModel.validators, true).apply(element.get("input"), path);
 			});
 
-			validators.put("output", outputValidator.getObjectValidation(CompatIOModel.validators));
+			validators.put("output", outputValidator.getObjectValidation(CompatIOModel.validators, true));
 		}
 
 		CompatValuesModel(String type, List<CompatIOModel> input, List<CompatIOModel> output) {
@@ -319,7 +320,7 @@ public class CompatModel {
 		 */
 		public static final Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
 		static {
-			validators.put("item", new Validator("item").RESOURCE_ID);
+			validators.put("item", new Validator("item").getResourceIDValidation(false));
 			validators.put("count", new Validator("count").getIntRange(0, 64, false));
 			validators.put("chance", new Validator("chance").getRange(0, 1, false));
 		}

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/EffectModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/EffectModel.java
@@ -24,13 +24,19 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.parser.model;
 
+import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraftforge.registries.ForgeRegistries;
 
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 public class EffectModel {
 	public static final Codec<EffectModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -49,6 +55,20 @@ public class EffectModel {
 	private final int level;
 	private final boolean showIcon;
 	private final boolean showParticles;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("effect", new Validator("effect").RESOURCE_ID_REQUIRED);
+		validators.put("level", new Validator("level").NON_EMPTY);
+		validators.put("showIcon", new Validator("showIcon").REQUIRES_BOOLEAN);
+		validators.put("showParticles", new Validator("showParticles").REQUIRES_BOOLEAN);
+	}
 
 	public EffectModel(String effect, int level, boolean showIcon, boolean showParticles) {
 		this.effect = effect;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/EffectModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/EffectModel.java
@@ -64,8 +64,8 @@ public class EffectModel {
 	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
 
 	static {
-		validators.put("effect", new Validator("effect").RESOURCE_ID_REQUIRED);
-		validators.put("level", new Validator("level").NON_EMPTY);
+		validators.put("effect", new Validator("effect").getRequiredResourceIDValidation(false));
+		validators.put("level", new Validator("level").REQUIRES_INT);
 		validators.put("showIcon", new Validator("showIcon").REQUIRES_BOOLEAN);
 		validators.put("showParticles", new Validator("showParticles").REQUIRES_BOOLEAN);
 	}

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialArmorModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialArmorModel.java
@@ -88,8 +88,8 @@ public class MaterialArmorModel {
 
 	static {
 		validators.put("setArmor", new Validator("setArmor").REQUIRES_BOOLEAN);
-		validators.put("setName", new Validator("setName").NON_EMPTY);
-		validators.put("setDesc", new Validator("setDesc").NON_EMPTY);
+		validators.put("setName", new Validator("setName").getNonEmptyValidation(false));
+		validators.put("setDesc", new Validator("setDesc").getNonEmptyValidation(false));
 		validators.put("toughness", new Validator("toughness").REQUIRES_FLOAT);
 		validators.put("enchantability", new Validator("enchantability").REQUIRES_INT);
 		validators.put("knockback", new Validator("knockback").REQUIRES_FLOAT);
@@ -112,10 +112,9 @@ public class MaterialArmorModel {
 			if (!required) {
 				if (Objects.isNull(valueJson)) return true;
 				LOGGER.warn("\"%s\" should not be present when it's missing from \"processedTypes\" in file \"%s\".".formatted(armorPiece, Validator.obfuscatePath(path)));
-				return validator.validateObject(valueJson, path, ArmorModel.validators);
 			}
 
-			return validator.getRequiredObjectValidation(ArmorModel.validators).apply(valueJson, path);
+			return validator.getRequiredObjectValidation(ArmorModel.validators, false).apply(valueJson, path);
 		};
 
 		validators.put("helmet_rg",   	(element, path) -> armorValidator.apply(new Validator("helmet"), element, path));

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialArmorModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialArmorModel.java
@@ -93,7 +93,7 @@ public class MaterialArmorModel {
 		validators.put("toughness", new Validator("toughness").REQUIRES_FLOAT);
 		validators.put("enchantability", new Validator("enchantability").REQUIRES_INT);
 		validators.put("knockback", new Validator("knockback").REQUIRES_FLOAT);
-		validators.put("effects", new Validator("effects").getObjectValidation(EffectModel.validators));
+		validators.put("effects", new Validator("effects").getObjectValidation(EffectModel.validators, true));
 
 		TriFunction<Validator, JsonElement, Path, Boolean> armorValidator = (validator, element, path) -> {
 			if (!validator.assertParentObject(element, path)) return false;
@@ -101,7 +101,7 @@ public class MaterialArmorModel {
 			JsonObject obj = element.getAsJsonObject();
 			boolean required = false;
 
-			if (!validator.checkForTEMP(obj, path, false)) {
+			if (!Validator.checkForTEMP(obj, path, false)) {
 				LOGGER.error("Parent object is missing while validating \"%s\" in file \"%s\". Something is not right.".formatted(armorPiece, Validator.obfuscatePath(path)));
 			} else {
 				required = obj.get("TEMP").getAsJsonObject().get(armorPiece).getAsBoolean();

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialArmorModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialArmorModel.java
@@ -29,10 +29,6 @@ import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.effect.MobEffect;
-import net.minecraft.world.effect.MobEffects;
-import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.commons.lang3.function.TriFunction;
 
 import java.nio.file.Path;
@@ -40,7 +36,6 @@ import java.util.*;
 import java.util.function.BiFunction;
 
 import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
-import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
 
 public class MaterialArmorModel {
 	public static final Codec<MaterialArmorModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -107,7 +102,7 @@ public class MaterialArmorModel {
 			boolean required = false;
 
 			if (!validator.checkForTEMP(obj, path, false)) {
-				if (log) LOGGER.error("Parent object is missing while validating \"%s\" in file \"%s\". Something is not right.".formatted(armorPiece, Validator.obfuscatePath(path)));
+				LOGGER.error("Parent object is missing while validating \"%s\" in file \"%s\". Something is not right.".formatted(armorPiece, Validator.obfuscatePath(path)));
 			} else {
 				required = obj.get("TEMP").getAsJsonObject().get(armorPiece).getAsBoolean();
 			}
@@ -116,7 +111,7 @@ public class MaterialArmorModel {
 
 			if (!required) {
 				if (Objects.isNull(valueJson)) return true;
-				if (log) LOGGER.warn("\"%s\" should not be present when it's missing from \"processedTypes\" in file \"%s\".".formatted(armorPiece, Validator.obfuscatePath(path)));
+				LOGGER.warn("\"%s\" should not be present when it's missing from \"processedTypes\" in file \"%s\".".formatted(armorPiece, Validator.obfuscatePath(path)));
 				return validator.validateObject(valueJson, path, ArmorModel.validators);
 			}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialArmorModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialArmorModel.java
@@ -24,16 +24,23 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.parser.model;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraftforge.registries.ForgeRegistries;
+import org.apache.commons.lang3.function.TriFunction;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.BiFunction;
+
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
 
 public class MaterialArmorModel {
 	public static final Codec<MaterialArmorModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -76,6 +83,52 @@ public class MaterialArmorModel {
 	private final ArmorModel leggings;
 	private final ArmorModel boots;
 	private final ArmorModel shield;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("setArmor", new Validator("setArmor").REQUIRES_BOOLEAN);
+		validators.put("setName", new Validator("setName").NON_EMPTY);
+		validators.put("setDesc", new Validator("setDesc").NON_EMPTY);
+		validators.put("toughness", new Validator("toughness").REQUIRES_FLOAT);
+		validators.put("enchantability", new Validator("enchantability").REQUIRES_INT);
+		validators.put("knockback", new Validator("knockback").REQUIRES_FLOAT);
+		validators.put("effects", new Validator("effects").getObjectValidation(EffectModel.validators));
+
+		TriFunction<Validator, JsonElement, Path, Boolean> armorValidator = (validator, element, path) -> {
+			if (!validator.assertParentObject(element, path)) return false;
+			String armorPiece = validator.getName();
+			JsonObject obj = element.getAsJsonObject();
+			boolean required = false;
+
+			if (!validator.checkForTEMP(obj, path, false)) {
+				if (log) LOGGER.error("Parent object is missing while validating \"%s\" in file \"%s\". Something is not right.".formatted(armorPiece, Validator.obfuscatePath(path)));
+			} else {
+				required = obj.get("TEMP").getAsJsonObject().get(armorPiece).getAsBoolean();
+			}
+
+			JsonElement valueJson = obj.get(armorPiece);
+
+			if (!required) {
+				if (Objects.isNull(valueJson)) return true;
+				if (log) LOGGER.warn("\"%s\" should not be present when it's missing from \"processedTypes\" in file \"%s\".".formatted(armorPiece, Validator.obfuscatePath(path)));
+				return validator.validateObject(valueJson, path, ArmorModel.validators);
+			}
+
+			return validator.getRequiredObjectValidation(ArmorModel.validators).apply(valueJson, path);
+		};
+
+		validators.put("helmet_rg",   	(element, path) -> armorValidator.apply(new Validator("helmet"), element, path));
+		validators.put("chestplate_rg", (element, path) -> armorValidator.apply(new Validator("chestplate"), element, path));
+		validators.put("leggings_rg",   (element, path) -> armorValidator.apply(new Validator("leggings"), element, path));
+		validators.put("boots_rg",  	(element, path) -> armorValidator.apply(new Validator("boots"), element, path));
+		validators.put("shield_rg",     (element, path) -> armorValidator.apply(new Validator("shield"), element, path));
+	}
 
 	public MaterialArmorModel(boolean setArmor, List<EffectModel> effects, String setName, String setDesc,
 	                          float toughness, float knockback, int enchantability,

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialColorsModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialColorsModel.java
@@ -33,7 +33,6 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import com.ridanisaurus.emendatusenigmatica.util.ColorHelper;
 import net.minecraft.data.models.blockstates.PropertyDispatch;
-import org.checkerframework.checker.units.qual.C;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
@@ -44,7 +43,6 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 
 import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
-import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
 
 public class MaterialColorsModel {
 	// TODO 3.0: Change gasColor to chemicalColor
@@ -90,8 +88,11 @@ public class MaterialColorsModel {
 			JsonObject obj = element.getAsJsonObject();
 			JsonElement valueJson = obj.get(gasValidator.getName());
 
-			if (!log || !gasValidator.checkForTEMP(obj, path, false)) {
-				if (log) LOGGER.warn("Parent data is missing while verifying \"%s\" in file \"%s\", something is not right.".formatted(gasValidator.getName(), Validator.obfuscatePath(path)));
+			if (!LOGGER.shouldLog || !gasValidator.checkForTEMP(obj, path, false)) {
+				LOGGER.warn(
+					"Parent data is missing while verifying \"%s\" in file \"%s\", something is not right."
+						.formatted(gasValidator.getName(), Validator.obfuscatePath(path))
+				);
 			} else {
 				JsonElement requiredJson = obj.get("TEMP").getAsJsonObject().get("processedTypes");
 				if (Objects.isNull(requiredJson)) {
@@ -125,8 +126,8 @@ public class MaterialColorsModel {
 			JsonObject obj = element.getAsJsonObject();
 			JsonElement valueJson = obj.get(validator.getName());
 
-			if (!log || !validator.checkForTEMP(obj, path, false)) {
-				if (log) LOGGER.warn("Parent data is missing while verifying \"%s\" in file \"%s\", something is not right.".formatted(validator.getName(), Validator.obfuscatePath(path)));
+			if (!LOGGER.shouldLog || !validator.checkForTEMP(obj, path, false)) {
+				LOGGER.warn("Parent data is missing while verifying \"%s\" in file \"%s\", something is not right.".formatted(validator.getName(), Validator.obfuscatePath(path)));
 			} else {
 				JsonElement requiredJson = obj.get("TEMP").getAsJsonObject().get("properties");
 				if (Objects.nonNull(requiredJson)) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialColorsModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialColorsModel.java
@@ -88,7 +88,7 @@ public class MaterialColorsModel {
 			JsonObject obj = element.getAsJsonObject();
 			JsonElement valueJson = obj.get(gasValidator.getName());
 
-			if (!LOGGER.shouldLog || !gasValidator.checkForTEMP(obj, path, false)) {
+			if (!LOGGER.shouldLog || !Validator.checkForTEMP(obj, path, false)) {
 				LOGGER.warn(
 					"Parent data is missing while verifying \"%s\" in file \"%s\", something is not right."
 						.formatted(gasValidator.getName(), Validator.obfuscatePath(path))
@@ -126,7 +126,7 @@ public class MaterialColorsModel {
 			JsonObject obj = element.getAsJsonObject();
 			JsonElement valueJson = obj.get(validator.getName());
 
-			if (!LOGGER.shouldLog || !validator.checkForTEMP(obj, path, false)) {
+			if (!LOGGER.shouldLog || !Validator.checkForTEMP(obj, path, false)) {
 				LOGGER.warn("Parent data is missing while verifying \"%s\" in file \"%s\", something is not right.".formatted(validator.getName(), Validator.obfuscatePath(path)));
 			} else {
 				JsonElement requiredJson = obj.get("TEMP").getAsJsonObject().get("properties");

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialColorsModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialColorsModel.java
@@ -74,12 +74,8 @@ public class MaterialColorsModel {
 	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
 
 	static {
-		validators.put("fluidColor", new Validator("fluidColor").HEX_COLOR);
-		validators.put("materialColor", new Validator("materialColor").HEX_COLOR);
-
-		validators.put("gasColor", new Validator("gasColor").HEX_COLOR);
-		validators.put("particlesColor", new Validator("particlesColor").HEX_COLOR);
-		validators.put("oxidizationColor", new Validator("oxidizationColor").HEX_COLOR);
+		validators.put("fluidColor", new Validator("fluidColor").getHexColorValidation(false));
+		validators.put("materialColor", new Validator("materialColor").getHexColorValidation(false));
 
 		Validator gasValidator = new Validator("gasColor");
 
@@ -118,7 +114,7 @@ public class MaterialColorsModel {
 				}
 			}
 
-			return gasValidator.HEX_COLOR.apply(obj.get(gasValidator.getName()), path);
+			return gasValidator.getHexColorValidation(false).apply(obj.get(gasValidator.getName()), path);
 		});
 
 		PropertyDispatch.QuadFunction<Validator, String, JsonElement, Path, Boolean> validationFunction = (validator, fieldName, element, path) -> {
@@ -160,7 +156,7 @@ public class MaterialColorsModel {
 				}
 			}
 
-			return validator.HEX_COLOR.apply(obj.get(gasValidator.getName()), path);
+			return validator.getHexColorValidation(false).apply(obj.get(gasValidator.getName()), path);
 		};
 
 		validators.put("particlesColor_rg", (element, path) -> validationFunction.apply(new Validator("particlesColor"), "hasParticles", element, path));

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialCompatModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialCompatModel.java
@@ -24,10 +24,16 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.parser.model;
 
+import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 public class MaterialCompatModel {
 	public static final Codec<MaterialCompatModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -52,6 +58,20 @@ public class MaterialCompatModel {
 	private final boolean ars_nouveau;
 	private final boolean blood_magic;
 	private final boolean occultism;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new HashMap<>();
+	static {
+		validators.put("create", new Validator("create").REQUIRES_BOOLEAN);
+		validators.put("thermal", new Validator("thermal").REQUIRES_BOOLEAN);
+		validators.put("mekanism", new Validator("mekanism").REQUIRES_BOOLEAN);
+		validators.put("ars_nouveau", new Validator("ars_nouveau").REQUIRES_BOOLEAN);
+		validators.put("occultism", new Validator("occultism").REQUIRES_BOOLEAN);
+	}
 
 	public MaterialCompatModel(boolean create, boolean thermal, boolean mekanism, boolean ars_nouveau, boolean blood_magic, boolean occultism) {
 		this.create = create;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialGasPropertiesModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialGasPropertiesModel.java
@@ -124,7 +124,7 @@ public class MaterialGasPropertiesModel {
 
 		Validator radioactivityValidator = new Validator("radioactivity");
 		validators.put(radioactivityValidator.getName() + "_rg", (element_rg, path) ->
-			isFieldSetValidator.apply(new Pair<>(radioactivityValidator, radioactivityValidator.REQUIRES_INT), "isRadioactive", element_rg, path)
+			isFieldSetValidator.apply(new Pair<>(radioactivityValidator, radioactivityValidator.REQUIRES_FLOAT), "isRadioactive", element_rg, path)
 		);
 
 		Validator coolantTypeValidator = new Validator("coolantType");

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialGasPropertiesModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialGasPropertiesModel.java
@@ -24,10 +24,20 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.parser.model;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import net.minecraft.data.models.blockstates.PropertyDispatch;
 
-import java.util.Optional;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.BiFunction;
+
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
 
 public class MaterialGasPropertiesModel {
 	public static final Codec<MaterialGasPropertiesModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -61,6 +71,78 @@ public class MaterialGasPropertiesModel {
 	private final String coolantType;
 	private final double thermalEnthalpy;
 	private final double conductivity;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("isBurnable", new Validator("isBurnable").REQUIRES_BOOLEAN);
+		validators.put("energyDensity", new Validator("energyDensity").REQUIRES_INT);
+		validators.put("isRadioactive", new Validator("isRadioactive").REQUIRES_BOOLEAN);
+		validators.put("isCoolant", new Validator("isCoolant").REQUIRES_BOOLEAN);
+
+		PropertyDispatch.QuadFunction<Pair<Validator, BiFunction<JsonElement, Path, Boolean>>, String, JsonElement, Path, Boolean> isFieldSetValidator = (validatorDetails, fieldName, element_rg, path) -> {
+			Validator validator = validatorDetails.getFirst();
+			if (!validator.assertParentObject(element_rg, path)) return false;
+
+			JsonObject obj = element_rg.getAsJsonObject();
+			JsonElement jsonBoolean = obj.get(fieldName);
+			JsonElement jsonValue = obj.get(validator.getName());
+
+			if (log) {
+				if (Objects.isNull(jsonBoolean)) {
+					if (Objects.nonNull(jsonValue)) {
+						LOGGER.warn(
+							"\"%s\" should not be present when \"%s\" is not present in file \"%s\"."
+								.formatted(validator.getName(), fieldName, Validator.obfuscatePath(path))
+						);
+					}
+				} else {
+					try {
+						boolean bol = jsonBoolean.getAsBoolean();
+						if (bol && Objects.isNull(jsonValue)) {
+							LOGGER.warn("\"%s\" should be specified if \"%s\" is true in file \"%s\".".formatted(validator.getName(), fieldName, Validator.obfuscatePath(path)));
+						} else if (!bol && Objects.nonNull(jsonValue)) {
+							LOGGER.warn("\"%s\" should not be present when \"%s\" is false in file \"%s\".".formatted(validator.getName(), fieldName, Validator.obfuscatePath(path)));
+						}
+					} catch (Exception e) {
+						LOGGER.error("\"%s\" is not boolean! Can't accurately verify value of \"%s\" in file \"%s\".".formatted(fieldName, validator.getName(), Validator.obfuscatePath(path)));
+					}
+				}
+			}
+
+			return validatorDetails.getSecond().apply(jsonValue, path);
+		};
+
+		Validator burnTimeValidator = new Validator("burnTime");
+		validators.put(burnTimeValidator.getName() + "_rg", (element_rg, path) ->
+			isFieldSetValidator.apply(new Pair<>(burnTimeValidator, burnTimeValidator.REQUIRES_INT), "isBurnable", element_rg, path)
+		);
+
+		Validator radioactivityValidator = new Validator("radioactivity");
+		validators.put(radioactivityValidator.getName() + "_rg", (element_rg, path) ->
+			isFieldSetValidator.apply(new Pair<>(radioactivityValidator, radioactivityValidator.REQUIRES_INT), "isRadioactive", element_rg, path)
+		);
+
+		Validator coolantTypeValidator = new Validator("coolantType");
+		validators.put(coolantTypeValidator.getName() + "_rg", (element_rg, path) ->
+			isFieldSetValidator.apply(new Pair<>(coolantTypeValidator, coolantTypeValidator.getAcceptsOnlyValidation(List.of("cooled", "heated"), false)), "isCoolant", element_rg, path)
+		);
+
+		Validator thermalValidator = new Validator("thermalEnthalpy");
+		validators.put(thermalValidator.getName() + "_rg", (element, path) ->
+			isFieldSetValidator.apply(new Pair<>(thermalValidator, thermalValidator.REQUIRES_FLOAT), "isCoolant", element, path)
+		);
+
+		Validator conductivityValidator = new Validator("conductivity");
+		validators.put(conductivityValidator.getName() + "_rg", (element, path) ->
+			isFieldSetValidator.apply(new Pair<>(conductivityValidator, conductivityValidator.REQUIRES_FLOAT), "isCoolant", element, path)
+		);
+	}
 
 	public MaterialGasPropertiesModel(boolean isBurnable, int burnTime, long energyDensity, boolean isRadioactive, double radioactivity,
 	                                  boolean isCoolant, String coolantType, double thermalEnthalpy, double conductivity) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialGasPropertiesModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialGasPropertiesModel.java
@@ -37,7 +37,6 @@ import java.util.*;
 import java.util.function.BiFunction;
 
 import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
-import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
 
 public class MaterialGasPropertiesModel {
 	public static final Codec<MaterialGasPropertiesModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -93,7 +92,7 @@ public class MaterialGasPropertiesModel {
 			JsonElement jsonBoolean = obj.get(fieldName);
 			JsonElement jsonValue = obj.get(validator.getName());
 
-			if (log) {
+			if (LOGGER.shouldLog) {
 				if (Objects.isNull(jsonBoolean)) {
 					if (Objects.nonNull(jsonValue)) {
 						LOGGER.warn(

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialModel.java
@@ -162,7 +162,7 @@ public class MaterialModel {
 			return validation.get();
 		});
 
-//		verifiers.put("properties", new Validator("properties").getObjectValidation(null));
+		verifiers.put("properties_rg", new Validator("properties").getPassParentToValidators(MaterialPropertiesModel.verifiers));
 //		verifiers.put("gas", new Validator("gas").getObjectValidation(null));
 //		verifiers.put("oreDrop", new Validator("oreDrop").getObjectValidation(null));
 //		verifiers.put("compat", new Validator("compat").getObjectValidation(null));

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialModel.java
@@ -96,14 +96,14 @@ public class MaterialModel {
 	 */
 	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new HashMap<>();
 	static {
-		validators.put("id", new Validator("id").getIDValidation(DefaultConfigPlugin.MATERIAL_IDS));
-		validators.put("source", new Validator("source").getRequiredAcceptsOnlyValidation(List.of("vanilla", "modded"), false));
-		validators.put("localizedName", new Validator("localizedName").NON_EMPTY_REQUIRED);
+		validators.put("id", 			new Validator("id")			.getIDValidation(DefaultConfigPlugin.MATERIAL_IDS));
+		validators.put("source",		new Validator("source")		.getRequiredAcceptsOnlyValidation(List.of("vanilla", "modded"), false));
+		validators.put("localizedName", new Validator("localizedName").getRequiredNonEmptyValidation(false));
+		validators.put("properties_rg", new Validator("properties")	.getPassParentToValidators(MaterialPropertiesModel.validators, false, false));
+		validators.put("colors_rg", 	new Validator("colors")		.getPassParentToValidators(MaterialColorsModel.validators, false, false));
+		validators.put("compat", 		new Validator("compat")		.getObjectValidation(MaterialCompatModel.validators, false));
+		validators.put("strata", 		new Validator("strata")		.getRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry", true));
 		validators.put("disableDefaultOre", new Validator("disableDefaultOre").REQUIRES_BOOLEAN);
-		validators.put("properties_rg", new Validator("properties").getPassParentToValidators(MaterialPropertiesModel.validators, false));
-		validators.put("colors_rg", new Validator("colors").getPassParentToValidators(MaterialColorsModel.validators, false));
-		validators.put("compat", new Validator("compat").getObjectValidation(MaterialCompatModel.validators));
-		validators.put("strata", new Validator("strata").getRegisteredIDValidation(DefaultConfigPlugin.STRATA_IDS, "Strata Registry", true));
 
 		Validator typesValidator = new Validator("processedTypes");
 		validators.put("processedTypes", (element, path) ->

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialModel.java
@@ -98,7 +98,7 @@ public class MaterialModel {
 	 */
 	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new HashMap<>();
 	static {
-		validators.put("id", new Validator("id").NON_EMPTY_REQUIRED);
+		validators.put("id", new Validator("id").getIDValidation(DefaultConfigPlugin.MATERIAL_IDS));
 		validators.put("source", new Validator("source").getRequiredAcceptsOnlyValidation(List.of("vanilla", "modded"), false));
 		validators.put("localizedName", new Validator("localizedName").NON_EMPTY_REQUIRED);
 		validators.put("disableDefaultOre", new Validator("disableDefaultOre").REQUIRES_BOOLEAN);

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialModel.java
@@ -138,11 +138,8 @@ public class MaterialModel {
 				"shard",
 				"clump",
 				"dirty_dust",
-				"crushed_ore"),
-			true).apply(element, path) &&
-			typesValidator.getIllegalPairsValidation(List.of(
-					new Pair<>("ingot", "gem")
-			)).apply(element, path)
+				"crushed_ore")
+			, true).apply(element, path) && typesValidator.getIllegalPairsValidation(List.of(new Pair<>("ingot", "gem"))).apply(element, path)
 		);
 
 		Validator oreDropValidator = new Validator("oreDrop");
@@ -179,7 +176,7 @@ public class MaterialModel {
 			return oreDropValidator.passTempToValidators(tempObj, valueJson, path, MaterialOreDropModel.validators, false);
 		});
 
-		// Yes, Tools and armor are nearly identical. I don't have any idea how to "unify" those however...
+		// Yes, Tools and armor are nearly identical. I don't have any idea how to "unify" those, however...
 		Validator toolsValidator = new Validator("tools");
 		validators.put(toolsValidator.getName() + "_rg", (element, path) -> {
 			if (!toolsValidator.assertParentObject(element, path)) return false;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialOreDropModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialOreDropModel.java
@@ -75,7 +75,7 @@ public class MaterialOreDropModel {
 			JsonObject obj = element.getAsJsonObject();
 			boolean required = false;
 
-			if (!dropValidator.checkForTEMP(obj, path, false)) {
+			if (!Validator.checkForTEMP(obj, path, false)) {
 				LOGGER.warn("Parent data is missing while verifying \"%s\" in file \"%s\", something is not right.".formatted(dropValidator.getName(), Validator.obfuscatePath(path)));
 			} else {
 				JsonElement requiredJson = obj.get("TEMP").getAsJsonObject().get("DROP_REQUIRED");

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialOreDropModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialOreDropModel.java
@@ -41,7 +41,6 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 
 import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
-import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
 
 public class MaterialOreDropModel {
 	public static final Codec<MaterialOreDropModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -77,11 +76,11 @@ public class MaterialOreDropModel {
 			boolean required = false;
 
 			if (!dropValidator.checkForTEMP(obj, path, false)) {
-				if (log) LOGGER.warn("Parent data is missing while verifying \"%s\" in file \"%s\", something is not right.".formatted(dropValidator.getName(), Validator.obfuscatePath(path)));
+				LOGGER.warn("Parent data is missing while verifying \"%s\" in file \"%s\", something is not right.".formatted(dropValidator.getName(), Validator.obfuscatePath(path)));
 			} else {
 				JsonElement requiredJson = obj.get("TEMP").getAsJsonObject().get("DROP_REQUIRED");
 				if (Objects.isNull(requiredJson)) {
-					if (log) LOGGER.warn("Parent data doesn't contain required information for proper validation of \"%s\" in file \"%s\", something is not right.".formatted(dropValidator.getName(), Validator.obfuscatePath(path)));
+					LOGGER.warn("Parent data doesn't contain required information for proper validation of \"%s\" in file \"%s\", something is not right.".formatted(dropValidator.getName(), Validator.obfuscatePath(path)));
 				} else {
 					required = requiredJson.getAsBoolean();
 				}
@@ -102,7 +101,7 @@ public class MaterialOreDropModel {
 				try {
 					min = obj.get("min").getAsInt();
 				} catch (ClassCastException e) {
-					if (log) LOGGER.error("\"min\" requested while validating \"max\" in file \"%s\" is not a numeric value!");
+					LOGGER.error("\"min\" requested while validating \"max\" in file \"%s\" is not a numeric value!");
 				}
 			}
 			return maxValidator.getIntRange(min, Integer.MAX_VALUE, false).apply(obj.get("max"), path);

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialOreDropModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialOreDropModel.java
@@ -24,13 +24,24 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.parser.model;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.registries.ForgeRegistries;
 
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
 
 public class MaterialOreDropModel {
 	public static final Codec<MaterialOreDropModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -49,6 +60,56 @@ public class MaterialOreDropModel {
 	private final int min;
 	private final int max;
 	private final boolean uniformCount;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		Validator dropValidator = new Validator("drop");
+		validators.put("drop_rg", (element, path) -> {
+			if (!dropValidator.assertParentObject(element, path)) return false;
+
+			JsonObject obj = element.getAsJsonObject();
+			boolean required = false;
+
+			if (!dropValidator.checkForTEMP(obj, path, false)) {
+				if (log) LOGGER.warn("Parent data is missing while verifying \"%s\" in file \"%s\", something is not right.".formatted(dropValidator.getName(), Validator.obfuscatePath(path)));
+			} else {
+				JsonElement requiredJson = obj.get("TEMP").getAsJsonObject().get("DROP_REQUIRED");
+				if (Objects.isNull(requiredJson)) {
+					if (log) LOGGER.warn("Parent data doesn't contain required information for proper validation of \"%s\" in file \"%s\", something is not right.".formatted(dropValidator.getName(), Validator.obfuscatePath(path)));
+				} else {
+					required = requiredJson.getAsBoolean();
+				}
+			}
+
+			JsonElement value = obj.get(dropValidator.getName());
+			return required? dropValidator.RESOURCE_ID_REQUIRED.apply(value, path): dropValidator.RESOURCE_ID.apply(value, path);
+		});
+
+		validators.put("min", new Validator("min").getIntRange(0, Integer.MAX_VALUE, false));
+
+		Validator maxValidator = new Validator("max");
+		validators.put("max_rg", (jsonElement, path) -> {
+			if (!maxValidator.assertParentObject(jsonElement, path)) return false;
+			JsonObject obj = jsonElement.getAsJsonObject();
+			int min = 0;
+			if (Objects.nonNull(obj.get("min"))) {
+				try {
+					min = obj.get("min").getAsInt();
+				} catch (ClassCastException e) {
+					if (log) LOGGER.error("\"min\" requested while validating \"max\" in file \"%s\" is not a numeric value!");
+				}
+			}
+			return maxValidator.getIntRange(min, Integer.MAX_VALUE, false).apply(obj.get("max"), path);
+		});
+
+		validators.put("uniformCount", new Validator("uniformCount").REQUIRES_BOOLEAN);
+	}
 
 	public MaterialOreDropModel(String drop, int min, int max, boolean uniformCount) {
 		this.drop = drop;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialPropertiesModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialPropertiesModel.java
@@ -24,8 +24,10 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.parser.model;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
@@ -33,8 +35,9 @@ import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
-import static com.ridanisaurus.emendatusenigmatica.EmendatusEnigmatica.LOGGER;
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
 import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
 
 public class MaterialPropertiesModel {
@@ -75,7 +78,7 @@ public class MaterialPropertiesModel {
 	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
 	 * Adding suffix _rg will request the original object instead of just the value of the field.
 	 */
-	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new HashMap<>();
+	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new LinkedHashMap<>();
 	static {
 		verifiers.put("materialType", new Validator("materialType").getRequiredAcceptsOnlyValidation(List.of("metal", "gem", "alloy")));
 		verifiers.put("harvestLevel", new Validator("harvestLevel").getRange(0, 4));
@@ -83,34 +86,130 @@ public class MaterialPropertiesModel {
 		verifiers.put("hasOxidation", Validator.ALL);
 		verifiers.put("isEmissive", Validator.ALL);
 		verifiers.put("isBurnable", Validator.ALL);
+
 		Validator burnTimeValidator = new Validator("burnTime");
 		verifiers.put("burnTime_rg", (element_rg, path) -> {
 			if (!burnTimeValidator.assertObject(element_rg, path)) return false;
 
 			JsonObject element = element_rg.getAsJsonObject();
 			JsonElement isBurnable = element.get("isBurnable");
-			JsonElement burnTime = element.get("burnTime");
+			JsonElement burnTime = element.get(burnTimeValidator.getName());
 
 			if (Objects.isNull(isBurnable)) {
-				if (log && Objects.nonNull(burnTime)) LOGGER.warn("burnTime should not be present when isBurnable is not present in file \"%s\".".formatted(Validator.obfuscatePath(path)));
+				if (log && Objects.nonNull(burnTime)) {
+					LOGGER.warn(
+						"\"%s\" should not be present when \"isBurnable\" is not present in file \"%s\"."
+							.formatted(burnTimeValidator.getName(), Validator.obfuscatePath(path))
+					);
+				}
 				return true;
 			}
 
 			try {
 				boolean bol = isBurnable.getAsBoolean();
 				if (log && bol && Objects.isNull(burnTime)) {
-					LOGGER.warn("burnTime should be specified if isBurnable is true in file \"%s\".".formatted(Validator.obfuscatePath(path)));
+					LOGGER.warn("\"%s\" should be specified if \"isBurnable\" is true in file \"%s\".".formatted(burnTimeValidator.getName(), Validator.obfuscatePath(path)));
 				} else if (log && !bol && Objects.nonNull(burnTime)) {
-					LOGGER.warn("burnTime should not be present when isBurnable is false in file \"%s\".".formatted(Validator.obfuscatePath(path)));
+					LOGGER.warn("\"%s\" should not be present when \"isBurnable\" is false in file \"%s\".".formatted(burnTimeValidator.getName(), Validator.obfuscatePath(path)));
 				}
 				return true;
 			} catch (ClassCastException e) {
-				if (log) LOGGER.error("isBurnable is not boolean! Can't verify value of burnTime in file \"%s\".".formatted(Validator.obfuscatePath(path)));
+				if (log) LOGGER.error("\"isBurnable\" is not boolean! Can't verify value of \"%s\" in file \"%s\".".formatted(Validator.obfuscatePath(path)), burnTimeValidator.getName());
 			}
 			return false;
 		});
 
-		//TODO. Finish this from here. Left: BlockRecipeType and GemTexture (requiring rework of everything above)
+		Validator blockRecipeValidator = new Validator("blockRecipeType");
+		List<Integer> acceptedValues = List.of(4, 9);
+		verifiers.put("blockRecipeType_rg", (element, path) -> {
+			if (!blockRecipeValidator.assertObject(element, path)) return false;
+
+			JsonObject obj = element.getAsJsonObject();
+			JsonElement valueJson = obj.get(blockRecipeValidator.getName());
+			JsonElement parent = obj.get("TEMP");
+
+			if (Objects.isNull(valueJson)) return true;
+
+			if (log && !blockRecipeValidator.checkForTEMP(obj, path, false)) {
+				LOGGER.error("No Parent object found while validating field \"%s\" in file \"%s\", something is not right.".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
+			} else if (log && blockRecipeValidator.assertObject(parent, path)) {
+				JsonElement typesElement = parent.getAsJsonObject().get("processedTypes");
+				if (Objects.isNull(typesElement)) {
+					LOGGER.warn("\"processedTypes\" is missing! Can't accurately verify values of \"%s\" in file \"%s\".".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
+				} else if (blockRecipeValidator.assertArray(typesElement, path)) {
+					JsonArray types = typesElement.getAsJsonArray();
+					boolean gem = types.contains(new JsonPrimitive("gem"));
+					boolean storage_block = types.contains(new JsonPrimitive("storage_block"));
+					if (!gem || !storage_block) {
+						LOGGER.warn(
+							"\"%s\" should not be present when \"gem\" %s \"storage_block\" aren't present in the \"processedTypes\" in file \"%s\"."
+								.formatted(blockRecipeValidator.getName(), gem || storage_block? "or":"and", Validator.obfuscatePath(path))
+						);
+					}
+				}
+			}
+
+			try {
+				double value = valueJson.getAsDouble();
+				if (log && Math.ceil(value) > value) {
+					LOGGER.warn("\"%s\" in file \"%s\" should be an integer. Floating-point values are not supported for this field.".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
+				}
+				int val = Double.valueOf(value).intValue();
+				boolean validation = acceptedValues.contains(val);
+				if (log && !validation) {
+					LOGGER.error("\"%s\" in file \"%s\" contains illegal value (%s)! Accepted values are: %s"
+						.formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path), val, acceptedValues.stream().map(String::valueOf).collect(Collectors.joining(", ")))
+					);
+				}
+				return validation;
+			} catch (ClassCastException e) {
+				if (log) LOGGER.error("\"%s\" in file \"%s\" requires a numeric value!".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
+			}
+
+			return false;
+		});
+
+		Validator GemTextureValidator = new Validator("gemTexture");
+		verifiers.put("gemTexture_rg", (element, path) -> {
+			if (!GemTextureValidator.assertObject(element, path)) return false;
+
+			JsonObject obj = element.getAsJsonObject();
+			JsonElement valueJson = obj.get(GemTextureValidator.getName());
+			JsonElement parent = obj.get("TEMP");
+
+			if (Objects.isNull(valueJson)) return true;
+
+			if (log && !GemTextureValidator.checkForTEMP(obj, path, false)) {
+				LOGGER.error("No Parent object found while validating field \"%s\" in file \"%s\", something is not right.".formatted(GemTextureValidator.getName(), Validator.obfuscatePath(path)));
+			} else if (log && GemTextureValidator.assertObject(parent, path)) {
+				JsonElement typesElement = parent.getAsJsonObject().get("processedTypes");
+				if (Objects.isNull(typesElement)) {
+					LOGGER.warn("\"processedTypes\" is missing! Can't accurately verify values of \"%s\" in file \"%s\".".formatted(GemTextureValidator.getName(), Validator.obfuscatePath(path)));
+				} else if (GemTextureValidator.assertArray(typesElement, path)) {
+					JsonArray types = typesElement.getAsJsonArray();
+					if (!types.contains(new JsonPrimitive("gem"))) {
+						LOGGER.warn(
+							"\"%s\" should not be present when \"gem\" isn't present in the \"processedTypes\" in file \"%s\"."
+								.formatted(GemTextureValidator.getName(), Validator.obfuscatePath(path))
+						);
+					}
+				}
+				JsonElement colors = parent.getAsJsonObject().get("colors");
+				if (Objects.isNull(colors) || !colors.isJsonObject()) {
+					LOGGER.warn(
+						"\"%s\" should not be present when \"colors\" object isn't present in file \"%s\"."
+							.formatted(GemTextureValidator.getName(), Validator.obfuscatePath(path))
+					);
+				} else if (Objects.isNull(colors.getAsJsonObject().get("materialColor"))) {
+					LOGGER.warn(
+						"\"%s\" should not be present in file \"%s\", the material isn't tint-based."
+							.formatted(GemTextureValidator.getName(), Validator.obfuscatePath(path))
+					);
+				}
+			}
+
+			return GemTextureValidator.getIntRange(0, 9).apply(valueJson, path);
+		});
 	}
 
 	public MaterialPropertiesModel(String materialType, int harvestLevel, int blockRecipeType, int gemTexture,

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialPropertiesModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialPropertiesModel.java
@@ -38,7 +38,6 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
-import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
 
 public class MaterialPropertiesModel {
 	public static final Codec<MaterialPropertiesModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -95,7 +94,7 @@ public class MaterialPropertiesModel {
 			JsonElement isBurnable = element.get("isBurnable");
 			JsonElement burnTime = element.get(burnTimeValidator.getName());
 
-			if (log) {
+			if (LOGGER.shouldLog) {
 				if (Objects.isNull(isBurnable)) {
 					if (Objects.nonNull(burnTime)) {
 						LOGGER.warn(
@@ -137,9 +136,9 @@ public class MaterialPropertiesModel {
 
 			if (Objects.isNull(valueJson)) return true;
 
-			if (log && !blockRecipeValidator.checkForTEMP(obj, path, false)) {
+			if (!LOGGER.shouldLog && !blockRecipeValidator.checkForTEMP(obj, path, false)) {
 				LOGGER.error("No Parent object found while validating field \"%s\" in file \"%s\", something is not right.".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
-			} else if (log && blockRecipeValidator.assertParentObject(parent, path)) {
+			} else if (blockRecipeValidator.assertParentObject(parent, path)) {
 				JsonElement typesElement = parent.getAsJsonObject().get("processedTypes");
 				if (Objects.isNull(typesElement)) {
 					LOGGER.warn("\"processedTypes\" is missing! Can't accurately verify values of \"%s\" in file \"%s\".".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
@@ -158,19 +157,19 @@ public class MaterialPropertiesModel {
 
 			try {
 				double value = valueJson.getAsDouble();
-				if (log && Math.ceil(value) > value) {
+				if (LOGGER.shouldLog && Math.ceil(value) > value) {
 					LOGGER.warn("\"%s\" in file \"%s\" should be an integer. Floating-point values are not supported for this field.".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
 				}
 				int val = Double.valueOf(value).intValue();
 				boolean validation = acceptedValues.contains(val);
-				if (log && !validation) {
+				if (!validation) {
 					LOGGER.error("\"%s\" in file \"%s\" contains illegal value (%s)! Accepted values are: %s"
 						.formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path), val, acceptedValues.stream().map(String::valueOf).collect(Collectors.joining(", ")))
 					);
 				}
 				return validation;
 			} catch (ClassCastException e) {
-				if (log) LOGGER.error("\"%s\" in file \"%s\" requires a numeric value!".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
+				LOGGER.error("\"%s\" in file \"%s\" requires a numeric value!".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
 			}
 
 			return false;
@@ -186,9 +185,9 @@ public class MaterialPropertiesModel {
 
 			if (Objects.isNull(valueJson)) return true;
 
-			if (log && !GemTextureValidator.checkForTEMP(obj, path, false)) {
+			if (!LOGGER.shouldLog && !GemTextureValidator.checkForTEMP(obj, path, false)) {
 				LOGGER.error("No Parent object found while validating field \"%s\" in file \"%s\", something is not right.".formatted(GemTextureValidator.getName(), Validator.obfuscatePath(path)));
-			} else if (log && GemTextureValidator.assertParentObject(parent, path)) {
+			} else if (GemTextureValidator.assertParentObject(parent, path)) {
 				JsonElement typesElement = parent.getAsJsonObject().get("processedTypes");
 				if (Objects.isNull(typesElement)) {
 					LOGGER.warn("\"processedTypes\" is missing! Can't accurately verify values of \"%s\" in file \"%s\".".formatted(GemTextureValidator.getName(), Validator.obfuscatePath(path)));

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialPropertiesModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialPropertiesModel.java
@@ -159,9 +159,12 @@ public class MaterialPropertiesModel {
 			try {
 				if (!valueJson.isJsonPrimitive()) throw new ClassCastException();
 				double value = valueJson.getAsDouble();
-				if (LOGGER.shouldLog && Math.ceil(value) > value) {
-					LOGGER.warn("\"%s\" in file \"%s\" should be an integer. Floating-point values are not supported for this field.".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
+
+				if (Math.ceil(value) > value) {
+					LOGGER.error("\"%s\" in file \"%s\" has to be an integer. Floating-point values are not supported for this field.".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
+					return false;
 				}
+
 				int val = Double.valueOf(value).intValue();
 				boolean validation = acceptedValues.contains(val);
 				if (!validation) {

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialPropertiesModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialPropertiesModel.java
@@ -104,6 +104,7 @@ public class MaterialPropertiesModel {
 					}
 				} else {
 					try {
+						if (!isBurnable.isJsonPrimitive()) throw new ClassCastException();
 						boolean bol = isBurnable.getAsBoolean();
 						if (bol && Objects.isNull(burnTime)) {
 							LOGGER.warn("Properties \"%s\" should be specified if Properties \"isBurnable\" is true in file \"%s\"."
@@ -136,7 +137,7 @@ public class MaterialPropertiesModel {
 
 			if (Objects.isNull(valueJson)) return true;
 
-			if (!LOGGER.shouldLog && !blockRecipeValidator.checkForTEMP(obj, path, false)) {
+			if (!LOGGER.shouldLog && !Validator.checkForTEMP(obj, path, false)) {
 				LOGGER.error("No Parent object found while validating field \"%s\" in file \"%s\", something is not right.".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
 			} else if (blockRecipeValidator.assertParentObject(parent, path)) {
 				JsonElement typesElement = parent.getAsJsonObject().get("processedTypes");
@@ -156,6 +157,7 @@ public class MaterialPropertiesModel {
 			}
 
 			try {
+				if (!valueJson.isJsonPrimitive()) throw new ClassCastException();
 				double value = valueJson.getAsDouble();
 				if (LOGGER.shouldLog && Math.ceil(value) > value) {
 					LOGGER.warn("\"%s\" in file \"%s\" should be an integer. Floating-point values are not supported for this field.".formatted(blockRecipeValidator.getName(), Validator.obfuscatePath(path)));
@@ -185,7 +187,7 @@ public class MaterialPropertiesModel {
 
 			if (Objects.isNull(valueJson)) return true;
 
-			if (!LOGGER.shouldLog && !GemTextureValidator.checkForTEMP(obj, path, false)) {
+			if (!LOGGER.shouldLog && !Validator.checkForTEMP(obj, path, false)) {
 				LOGGER.error("No Parent object found while validating field \"%s\" in file \"%s\", something is not right.".formatted(GemTextureValidator.getName(), Validator.obfuscatePath(path)));
 			} else if (GemTextureValidator.assertParentObject(parent, path)) {
 				JsonElement typesElement = parent.getAsJsonObject().get("processedTypes");

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialToolsModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialToolsModel.java
@@ -24,10 +24,22 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.parser.model;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
 
+import org.apache.commons.lang3.function.TriFunction;
+
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 public class MaterialToolsModel {
 	public static final Codec<MaterialToolsModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -53,8 +65,7 @@ public class MaterialToolsModel {
 			hoe.orElse(new ToolModel()),
 			paxel.orElse(new ToolModel())
 	)));
-
-	private final float attackDamage;
+    private final float attackDamage;
 	private final int level;
 	private final int enchantability;
 	private final float efficiency;
@@ -64,6 +75,50 @@ public class MaterialToolsModel {
 	private final ToolModel shovel;
 	private final ToolModel hoe;
 	private final ToolModel paxel;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("attackDamage", new Validator("attackDamage").getRequiredRange(0, Integer.MAX_VALUE, false));
+		validators.put("level", new Validator("level").getRequiredRange(0, Integer.MAX_VALUE, false));
+		validators.put("enchantability", new Validator("enchantability").getRequiredRange(0, Integer.MAX_VALUE, false));
+		validators.put("efficiency", new Validator("efficiency").getRequiredRange(0, Integer.MAX_VALUE, false));
+
+		TriFunction<Validator, JsonElement, Path, Boolean> toolValidator = (validator, element, path) -> {
+			if (!validator.assertParentObject(element, path)) return false;
+			String tool = validator.getName();
+			JsonObject obj = element.getAsJsonObject();
+			boolean required = false;
+
+			if (!validator.checkForTEMP(obj, path, false)) {
+				if (log) LOGGER.error("Parent object is missing while validating \"%s\" in file \"%s\". Something is not right.".formatted(tool, Validator.obfuscatePath(path)));
+			} else {
+				required = obj.get("TEMP").getAsJsonObject().get(tool).getAsBoolean();
+			}
+
+			JsonElement valueJson = obj.get(tool);
+
+			if (!required) {
+				if (Objects.isNull(valueJson)) return true;
+				if (log) LOGGER.warn("\"%s\" should not be present when it's missing from \"processedTypes\" in file \"%s\".".formatted(tool, Validator.obfuscatePath(path)));
+				return validator.validateObject(valueJson, path, ToolModel.validators);
+			}
+
+			return validator.getRequiredObjectValidation(ToolModel.validators).apply(valueJson, path);
+		};
+
+		validators.put("sword_rg",   (element, path) -> toolValidator.apply(new Validator("sword"), element, path));
+		validators.put("pickaxe_rg", (element, path) -> toolValidator.apply(new Validator("pickaxe"), element, path));
+		validators.put("axe_rg",     (element, path) -> toolValidator.apply(new Validator("axe"), element, path));
+		validators.put("shovel_rg",  (element, path) -> toolValidator.apply(new Validator("shovel"), element, path));
+		validators.put("hoe_rg",     (element, path) -> toolValidator.apply(new Validator("hoe"), element, path));
+		validators.put("paxel_rg",   (element, path) -> toolValidator.apply(new Validator("paxel"), element, path));
+	}
 
 	public MaterialToolsModel(float attackDamage, int level, int enchantability, float efficiency, ToolModel sword, ToolModel pickaxe, ToolModel axe, ToolModel shovel, ToolModel hoe, ToolModel paxel) {
 		this.attackDamage = attackDamage;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialToolsModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialToolsModel.java
@@ -94,7 +94,7 @@ public class MaterialToolsModel {
 			JsonObject obj = element.getAsJsonObject();
 			boolean required = false;
 
-			if (!validator.checkForTEMP(obj, path, false)) {
+			if (!Validator.checkForTEMP(obj, path, false)) {
 				LOGGER.error("Parent object is missing while validating \"%s\" in file \"%s\". Something is not right.".formatted(tool, Validator.obfuscatePath(path)));
 			} else {
 				required = obj.get("TEMP").getAsJsonObject().get(tool).getAsBoolean();

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialToolsModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialToolsModel.java
@@ -29,9 +29,6 @@ import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
-import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
-import static com.ridanisaurus.emendatusenigmatica.loader.Validator.log;
-
 import org.apache.commons.lang3.function.TriFunction;
 
 import java.nio.file.Path;
@@ -40,6 +37,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
+
+import static com.ridanisaurus.emendatusenigmatica.loader.Validator.LOGGER;
 
 public class MaterialToolsModel {
 	public static final Codec<MaterialToolsModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -96,7 +95,7 @@ public class MaterialToolsModel {
 			boolean required = false;
 
 			if (!validator.checkForTEMP(obj, path, false)) {
-				if (log) LOGGER.error("Parent object is missing while validating \"%s\" in file \"%s\". Something is not right.".formatted(tool, Validator.obfuscatePath(path)));
+				LOGGER.error("Parent object is missing while validating \"%s\" in file \"%s\". Something is not right.".formatted(tool, Validator.obfuscatePath(path)));
 			} else {
 				required = obj.get("TEMP").getAsJsonObject().get(tool).getAsBoolean();
 			}
@@ -105,7 +104,7 @@ public class MaterialToolsModel {
 
 			if (!required) {
 				if (Objects.isNull(valueJson)) return true;
-				if (log) LOGGER.warn("\"%s\" should not be present when it's missing from \"processedTypes\" in file \"%s\".".formatted(tool, Validator.obfuscatePath(path)));
+				LOGGER.warn("\"%s\" should not be present when it's missing from \"processedTypes\" in file \"%s\".".formatted(tool, Validator.obfuscatePath(path)));
 				return validator.validateObject(valueJson, path, ToolModel.validators);
 			}
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialToolsModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/MaterialToolsModel.java
@@ -108,7 +108,7 @@ public class MaterialToolsModel {
 				return validator.validateObject(valueJson, path, ToolModel.validators);
 			}
 
-			return validator.getRequiredObjectValidation(ToolModel.validators).apply(valueJson, path);
+			return validator.getRequiredObjectValidation(ToolModel.validators, false).apply(valueJson, path);
 		};
 
 		validators.put("sword_rg",   (element, path) -> toolValidator.apply(new Validator("sword"), element, path));

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/StrataModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/StrataModel.java
@@ -24,11 +24,18 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.parser.model;
 
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.resources.ResourceLocation;
 
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 public class StrataModel {
 	public static final Codec<StrataModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -52,6 +59,29 @@ public class StrataModel {
 			f2.orElse(3f),
 			b.orElse(false)
 	)));
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new HashMap<>();
+	static {
+		verifiers.put("id", new Validator("id").NON_EMPTY_REQUIRED);
+		verifiers.put("baseTexture", new Validator("baseTexture").NON_EMPTY_REQUIRED);
+		verifiers.put("suffix", new Validator("suffix").NON_EMPTY_REQUIRED);
+		verifiers.put("fillerType", new Validator("fillerType").NON_EMPTY_REQUIRED);
+		verifiers.put("localizedName", new Validator("localizedName").NON_EMPTY_REQUIRED);
+		verifiers.put("harvestTool", new Validator("harvestTool").getAcceptsOnlyValidation(List.of(
+				"pickaxe",
+				"axe",
+				"hoe",
+				"shovel"
+		)));
+		verifiers.put("hardness", new Validator("hardness").getRange(0, Integer.MAX_VALUE));
+		verifiers.put("resistance", new Validator("resistance").getRange(0, Integer.MAX_VALUE));
+		verifiers.put("sampleStrata", Validator.ALL);
+	}
 
 	private final String id;
 	private final ResourceLocation baseTexture;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/StrataModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/StrataModel.java
@@ -68,20 +68,20 @@ public class StrataModel {
 	 */
 	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new HashMap<>();
 	static {
-		validators.put("id", new Validator("id").getIDValidation(DefaultConfigPlugin.STRATA_IDS));
-		validators.put("suffix", new Validator("suffix").NON_EMPTY_REQUIRED);
-		validators.put("localizedName", new Validator("localizedName").NON_EMPTY_REQUIRED);
-		validators.put("baseTexture", new Validator("baseTexture").RESOURCE_ID_REQUIRED);
-		validators.put("fillerType", new Validator("fillerType").RESOURCE_ID_REQUIRED);
-		validators.put("harvestTool", new Validator("harvestTool").getAcceptsOnlyValidation(List.of(
+		validators.put("id", 			new Validator("id").getIDValidation(DefaultConfigPlugin.STRATA_IDS));
+		validators.put("baseTexture", 	new Validator("baseTexture").getRequiredResourceIDValidation(false));
+		validators.put("suffix", 		new Validator("suffix").getRequiredNonEmptyValidation(false));
+		validators.put("fillerType", 	new Validator("fillerType").getRequiredResourceIDValidation(false));
+		validators.put("localizedName", new Validator("localizedName").getRequiredNonEmptyValidation(false));
+		validators.put("hardness", 		new Validator("hardness").getRange(0, Integer.MAX_VALUE, false));
+		validators.put("resistance", 	new Validator("resistance").getRange(0, Integer.MAX_VALUE, false));
+		validators.put("sampleStrata", 	new Validator("sampleStrata").REQUIRES_BOOLEAN);
+		validators.put("harvestTool", 	new Validator("harvestTool").getAcceptsOnlyValidation(List.of(
 				"pickaxe",
 				"axe",
 				"hoe",
 				"shovel"
 		), false));
-		validators.put("hardness", new Validator("hardness").getRange(0, Integer.MAX_VALUE, false));
-		validators.put("resistance", new Validator("resistance").getRange(0, Integer.MAX_VALUE, false));
-		validators.put("sampleStrata", new Validator("sampleStrata").REQUIRES_BOOLEAN);
 	}
 
 	private final String id;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/StrataModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/StrataModel.java
@@ -68,7 +68,7 @@ public class StrataModel {
 	 */
 	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new HashMap<>();
 	static {
-		validators.put("id", new Validator("id").getRequiredIllegalValuesValidation(DefaultConfigPlugin.STRATA_IDS, false));
+		validators.put("id", new Validator("id").getIDValidation(DefaultConfigPlugin.STRATA_IDS));
 		validators.put("suffix", new Validator("suffix").NON_EMPTY_REQUIRED);
 		validators.put("localizedName", new Validator("localizedName").NON_EMPTY_REQUIRED);
 		validators.put("baseTexture", new Validator("baseTexture").RESOURCE_ID_REQUIRED);

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/StrataModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/StrataModel.java
@@ -65,22 +65,22 @@ public class StrataModel {
 	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
 	 * Adding suffix _rg will request the original object instead of just the value of the field.
 	 */
-	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> verifiers = new HashMap<>();
+	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new HashMap<>();
 	static {
-		verifiers.put("id", new Validator("id").NON_EMPTY_REQUIRED);
-		verifiers.put("baseTexture", new Validator("baseTexture").NON_EMPTY_REQUIRED);
-		verifiers.put("suffix", new Validator("suffix").NON_EMPTY_REQUIRED);
-		verifiers.put("fillerType", new Validator("fillerType").NON_EMPTY_REQUIRED);
-		verifiers.put("localizedName", new Validator("localizedName").NON_EMPTY_REQUIRED);
-		verifiers.put("harvestTool", new Validator("harvestTool").getAcceptsOnlyValidation(List.of(
+		validators.put("id", new Validator("id").NON_EMPTY_REQUIRED);
+		validators.put("suffix", new Validator("suffix").NON_EMPTY_REQUIRED);
+		validators.put("localizedName", new Validator("localizedName").NON_EMPTY_REQUIRED);
+		validators.put("baseTexture", new Validator("baseTexture").RESOURCE_ID_REQUIRED);
+		validators.put("fillerType", new Validator("fillerType").RESOURCE_ID_REQUIRED);
+		validators.put("harvestTool", new Validator("harvestTool").getAcceptsOnlyValidation(List.of(
 				"pickaxe",
 				"axe",
 				"hoe",
 				"shovel"
-		)));
-		verifiers.put("hardness", new Validator("hardness").getRange(0, Integer.MAX_VALUE));
-		verifiers.put("resistance", new Validator("resistance").getRange(0, Integer.MAX_VALUE));
-		verifiers.put("sampleStrata", Validator.ALL);
+		), false));
+		validators.put("hardness", new Validator("hardness").getRange(0, Integer.MAX_VALUE, false));
+		validators.put("resistance", new Validator("resistance").getRange(0, Integer.MAX_VALUE, false));
+		validators.put("sampleStrata", new Validator("sampleStrata").REQUIRES_BOOLEAN);
 	}
 
 	private final String id;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/StrataModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/StrataModel.java
@@ -28,6 +28,7 @@ import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.plugin.DefaultConfigPlugin;
 import net.minecraft.resources.ResourceLocation;
 
 import java.nio.file.Path;
@@ -67,7 +68,7 @@ public class StrataModel {
 	 */
 	public static final Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new HashMap<>();
 	static {
-		validators.put("id", new Validator("id").NON_EMPTY_REQUIRED);
+		validators.put("id", new Validator("id").getRequiredIllegalValuesValidation(DefaultConfigPlugin.STRATA_IDS, false));
 		validators.put("suffix", new Validator("suffix").NON_EMPTY_REQUIRED);
 		validators.put("localizedName", new Validator("localizedName").NON_EMPTY_REQUIRED);
 		validators.put("baseTexture", new Validator("baseTexture").RESOURCE_ID_REQUIRED);

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/ToolModel.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/loader/parser/model/ToolModel.java
@@ -24,10 +24,16 @@
 
 package com.ridanisaurus.emendatusenigmatica.loader.parser.model;
 
+import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.ridanisaurus.emendatusenigmatica.loader.Validator;
 
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 public class ToolModel {
 	public static final Codec<ToolModel> CODEC = RecordCodecBuilder.create(x -> x.group(
@@ -43,6 +49,19 @@ public class ToolModel {
 	private final float damage;
 	private final float speed;
 	private final int durability;
+
+	/**
+	 * Holds verifying functions for each field.
+	 * Function returns true if verification was successful, false otherwise to stop registration of the json.
+	 * Adding suffix _rg will request the original object instead of just the value of the field.
+	 */
+	public static Map<String, BiFunction<JsonElement, Path, Boolean>> validators = new LinkedHashMap<>();
+
+	static {
+		validators.put("damage", new Validator("damage").REQUIRES_FLOAT);
+		validators.put("speed", new Validator("speed").REQUIRES_FLOAT);
+		validators.put("durability", new Validator("durability").REQUIRES_INT);
+	}
 
 	public ToolModel(float damage, float speed, int durability) {
 		this.damage = damage;

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/plugin/DefaultConfigPlugin.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/plugin/DefaultConfigPlugin.java
@@ -127,14 +127,6 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
             CompatModel compatModel = result.get().getFirst();
             registry.registerCompat(compatModel);
         });
-
-        LOGGER.restartSpacer();
-        if (LOGGER.shouldLog)  {
-            LOGGER.info("Finished validation and registration of data files.");
-        } else {
-            LOGGER.info("Finished registration of data files. Any validation errors that occurred have been hidden due to your current configuration.");
-        }
-        LOGGER.printSpacer(0);
     }
 
     @Override

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/plugin/DefaultConfigPlugin.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/plugin/DefaultConfigPlugin.java
@@ -30,10 +30,11 @@ import java.util.Optional;
 //This plugin will be always first
 @EmendatusPluginReference(modid = Reference.MOD_ID, name = "config")
 public class DefaultConfigPlugin implements IEmendatusPlugin {
-    public static final List<MaterialModel> MATERIALS = new ArrayList<>();
     public static final List<String> MATERIAL_IDS = new ArrayList<>();
-    public static final List<StrataModel> STRATA = new ArrayList<>();
     public static final List<String> STRATA_IDS = new ArrayList<>();
+    public static final List<MaterialModel> MATERIALS = new ArrayList<>();
+    // Not used anywhere, commented to reduce memory usage a bit.
+//    public static final List<StrataModel> STRATA = new ArrayList<>();
 
     @Override
     public void load(EmendatusDataRegistry registry) {
@@ -84,7 +85,7 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
 
             StrataModel strataModel = result.get().getFirst();
             registry.registerStrata(strataModel);
-            STRATA.add(strataModel);
+//            STRATA.add(strataModel);
             STRATA_IDS.add(strataModel.getId());
         });
 

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/plugin/DefaultConfigPlugin.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/plugin/DefaultConfigPlugin.java
@@ -2,7 +2,6 @@ package com.ridanisaurus.emendatusenigmatica.plugin;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.JsonOps;
 import com.ridanisaurus.emendatusenigmatica.EmendatusEnigmatica;
@@ -27,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 //This plugin will be always first
 @EmendatusPluginReference(modid = Reference.MOD_ID, name = "config")
@@ -66,13 +64,18 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
         Map<Path, JsonObject> strataDefinition = FileHelper.loadJsonsWithPaths(strataDir.toPath());
         Map<Path, JsonObject> materialDefinition = FileHelper.loadJsonsWithPaths(materialDir.toPath());
         Map<Path, JsonObject> compatDefinition = FileHelper.loadJsonsWithPaths(compatDir.toPath());
+
         Validator validator = new Validator("Main Validator");
         final boolean log = EEConfig.common.logConfigErrors.get();
 
         Validator.LOGGER.info("Validating and registering data for: Strata");
         strataDefinition.forEach((path, jsonObject) -> {
-            if (!validator.validateObject(jsonObject, path, StrataModel.verifiers)) {
-                if (log) Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+            Validator.LOGGER.restartSpacer();
+            if (!validator.validateObject(jsonObject, path, StrataModel.validators)) {
+                if (log) {
+                    Validator.LOGGER.printSpacer(2);
+                    Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+                }
                 return;
             }
 
@@ -85,10 +88,15 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
             STRATA_IDS.add(strataModel.getId());
         });
 
+        Validator.LOGGER.restartSpacer();
         Validator.LOGGER.info("Validating and registering data for: Material");
         materialDefinition.forEach((path, jsonObject) -> {
-            if (!validator.validateObject(jsonObject, path, MaterialModel.verifiers)) {
-                if (log) Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+            Validator.LOGGER.restartSpacer();
+            if (!validator.validateObject(jsonObject, path, MaterialModel.validators)) {
+                if (log) {
+                    Validator.LOGGER.printSpacer(2);
+                    Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+                }
                 return;
             }
 
@@ -101,10 +109,15 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
             MATERIAL_IDS.add(materialModel.getId());
         });
 
+        Validator.LOGGER.restartSpacer();
         Validator.LOGGER.info("Validating and registering data for: Compatibility");
         compatDefinition.forEach((path, jsonObject) -> {
-            if (!validator.validateObject(jsonObject, path, CompatModel.verifiers)) {
-                if (log) Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+            Validator.LOGGER.restartSpacer();
+            if (!validator.validateObject(jsonObject, path, CompatModel.validators)) {
+                if (log) {
+                    Validator.LOGGER.printSpacer(2);
+                    Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+                }
                 return;
             }
 
@@ -115,11 +128,13 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
             registry.registerCompat(compatModel);
         });
 
+        Validator.LOGGER.restartSpacer();
         if (log)  {
             Validator.LOGGER.info("Finished validation and registration of data files.");
         } else {
             Validator.LOGGER.info("Finished registration of data files. Any validation errors that occurred have been hidden due to your current configuration.");
         }
+        Validator.LOGGER.printSpacer(0);
     }
 
     @Override

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/plugin/DefaultConfigPlugin.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/plugin/DefaultConfigPlugin.java
@@ -8,9 +8,9 @@ import com.ridanisaurus.emendatusenigmatica.EmendatusEnigmatica;
 import com.ridanisaurus.emendatusenigmatica.api.EmendatusDataRegistry;
 import com.ridanisaurus.emendatusenigmatica.api.IEmendatusPlugin;
 import com.ridanisaurus.emendatusenigmatica.api.annotation.EmendatusPluginReference;
-import com.ridanisaurus.emendatusenigmatica.config.EEConfig;
 import com.ridanisaurus.emendatusenigmatica.datagen.*;
 import com.ridanisaurus.emendatusenigmatica.loader.Validator;
+import com.ridanisaurus.emendatusenigmatica.loader.ValidatorLogger;
 import com.ridanisaurus.emendatusenigmatica.loader.parser.model.CompatModel;
 import com.ridanisaurus.emendatusenigmatica.loader.parser.model.MaterialModel;
 import com.ridanisaurus.emendatusenigmatica.loader.parser.model.StrataModel;
@@ -66,15 +66,15 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
         Map<Path, JsonObject> compatDefinition = FileHelper.loadJsonsWithPaths(compatDir.toPath());
 
         Validator validator = new Validator("Main Validator");
-        final boolean log = EEConfig.common.logConfigErrors.get();
+        ValidatorLogger LOGGER = Validator.LOGGER;
 
-        Validator.LOGGER.info("Validating and registering data for: Strata");
+        LOGGER.info("Validating and registering data for: Strata");
         strataDefinition.forEach((path, jsonObject) -> {
-            Validator.LOGGER.restartSpacer();
+            LOGGER.restartSpacer();
             if (!validator.validateObject(jsonObject, path, StrataModel.validators)) {
-                if (log) {
-                    Validator.LOGGER.printSpacer(2);
-                    Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+                if (LOGGER.shouldLog) {
+                    LOGGER.printSpacer(2);
+                    LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
                 }
                 return;
             }
@@ -88,14 +88,14 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
             STRATA_IDS.add(strataModel.getId());
         });
 
-        Validator.LOGGER.restartSpacer();
-        Validator.LOGGER.info("Validating and registering data for: Material");
+        LOGGER.restartSpacer();
+        LOGGER.info("Validating and registering data for: Material");
         materialDefinition.forEach((path, jsonObject) -> {
-            Validator.LOGGER.restartSpacer();
+            LOGGER.restartSpacer();
             if (!validator.validateObject(jsonObject, path, MaterialModel.validators)) {
-                if (log) {
-                    Validator.LOGGER.printSpacer(2);
-                    Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+                if (LOGGER.shouldLog) {
+                    LOGGER.printSpacer(2);
+                    LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
                 }
                 return;
             }
@@ -109,14 +109,14 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
             MATERIAL_IDS.add(materialModel.getId());
         });
 
-        Validator.LOGGER.restartSpacer();
-        Validator.LOGGER.info("Validating and registering data for: Compatibility");
+        LOGGER.restartSpacer();
+        LOGGER.info("Validating and registering data for: Compatibility");
         compatDefinition.forEach((path, jsonObject) -> {
-            Validator.LOGGER.restartSpacer();
+            LOGGER.restartSpacer();
             if (!validator.validateObject(jsonObject, path, CompatModel.validators)) {
-                if (log) {
-                    Validator.LOGGER.printSpacer(2);
-                    Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+                if (LOGGER.shouldLog) {
+                    LOGGER.printSpacer(2);
+                    LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
                 }
                 return;
             }
@@ -128,13 +128,13 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
             registry.registerCompat(compatModel);
         });
 
-        Validator.LOGGER.restartSpacer();
-        if (log)  {
-            Validator.LOGGER.info("Finished validation and registration of data files.");
+        LOGGER.restartSpacer();
+        if (LOGGER.shouldLog)  {
+            LOGGER.info("Finished validation and registration of data files.");
         } else {
-            Validator.LOGGER.info("Finished registration of data files. Any validation errors that occurred have been hidden due to your current configuration.");
+            LOGGER.info("Finished registration of data files. Any validation errors that occurred have been hidden due to your current configuration.");
         }
-        Validator.LOGGER.printSpacer(0);
+        LOGGER.printSpacer(0);
     }
 
     @Override

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/plugin/DefaultConfigPlugin.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/plugin/DefaultConfigPlugin.java
@@ -69,10 +69,10 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
         Validator validator = new Validator("Main Validator");
         final boolean log = EEConfig.common.logConfigErrors.get();
 
-        EmendatusEnigmatica.LOGGER.info("Validating and registering data for: Strata");
+        Validator.LOGGER.info("Validating and registering data for: Strata");
         strataDefinition.forEach((path, jsonObject) -> {
             if (!validator.validateObject(jsonObject, path, StrataModel.verifiers)) {
-                if (log) EmendatusEnigmatica.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+                if (log) Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
                 return;
             }
 
@@ -85,10 +85,10 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
             STRATA_IDS.add(strataModel.getId());
         });
 
-        EmendatusEnigmatica.LOGGER.info("Validating and registering data for: Material");
+        Validator.LOGGER.info("Validating and registering data for: Material");
         materialDefinition.forEach((path, jsonObject) -> {
             if (!validator.validateObject(jsonObject, path, MaterialModel.verifiers)) {
-                if (log) EmendatusEnigmatica.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+                if (log) Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
                 return;
             }
 
@@ -101,10 +101,10 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
             MATERIAL_IDS.add(materialModel.getId());
         });
 
-        EmendatusEnigmatica.LOGGER.info("Validating and registering data for: Compatibility");
+        Validator.LOGGER.info("Validating and registering data for: Compatibility");
         compatDefinition.forEach((path, jsonObject) -> {
             if (!validator.validateObject(jsonObject, path, CompatModel.verifiers)) {
-                if (log) EmendatusEnigmatica.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
+                if (log) Validator.LOGGER.error("File \"%s\" is not going to be registered due to errors in it's validation.".formatted(path));
                 return;
             }
 
@@ -116,11 +116,10 @@ public class DefaultConfigPlugin implements IEmendatusPlugin {
         });
 
         if (log)  {
-            EmendatusEnigmatica.LOGGER.info("Finished validation and registration of data files.");
+            Validator.LOGGER.info("Finished validation and registration of data files.");
         } else {
-            EmendatusEnigmatica.LOGGER.info("Finished registration of data files. Any validation errors that occurred have been hidden due to your current configuration.");
+            Validator.LOGGER.info("Finished registration of data files. Any validation errors that occurred have been hidden due to your current configuration.");
         }
-        throw new RuntimeException();
     }
 
     @Override

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/renderers/PatreonRewardRenderer.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/renderers/PatreonRewardRenderer.java
@@ -47,6 +47,7 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -66,7 +67,7 @@ public class PatreonRewardRenderer extends RenderLayer<AbstractClientPlayer, Pla
 	}
 
 	@Override
-	public void render(PoseStack matrixStack, MultiBufferSource buffer, int packedLight, AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
+	public void render(@NotNull PoseStack matrixStack, @NotNull MultiBufferSource buffer, int packedLight, @NotNull AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
 		String name = player.getGameProfile().getName();
 		Level world = player.getCommandSenderWorld();
 
@@ -92,7 +93,6 @@ public class PatreonRewardRenderer extends RenderLayer<AbstractClientPlayer, Pla
 
 		@Override
 		public void run() {
-			Gson jsonParser = new Gson();
 			try {
 				var url = new URL("https://raw.githubusercontent.com/Ridanisaurus/EmendatusEnigmatica/EEV2-1.19/patreon_supporters_list.json");
 				var reader = new JsonReader(new InputStreamReader(url.openStream()));

--- a/src/main/java/com/ridanisaurus/emendatusenigmatica/util/FileHelper.java
+++ b/src/main/java/com/ridanisaurus/emendatusenigmatica/util/FileHelper.java
@@ -1,43 +1,65 @@
 package com.ridanisaurus.emendatusenigmatica.util;
 
+import com.ridanisaurus.emendatusenigmatica.EmendatusEnigmatica;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.ridanisaurus.emendatusenigmatica.EmendatusEnigmatica;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.filefilter.FileFilterUtils;
 
 import java.io.File;
-import java.io.FileFilter;
-import java.io.FileReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
 
 public class FileHelper {
-	public static ArrayList<JsonObject> loadFilesAsJsonObjects(File dir) {
-		ArrayList<JsonObject> results = new ArrayList<>();
-		File[] files = dir.listFiles(
-//				(FileFilter) FileFilterUtils.suffixFileFilter(".json")
-		);
 
-		if (files == null || files.length <= 0) {
-			return new ArrayList<>();
+	/**
+	 * Used to get only values from the files in specified directory.
+	 * @param dir File representing the directory to load from. Subdirectories will also be loaded.
+	 * @return ArrayList with JsonObjects parsed from found .json files.
+	 * @apiNote It is recommended to use {@link FileHelper#loadJsons(Path)} instead.
+	 */
+	public static ArrayList<JsonObject> loadFilesAsJsonObjects(File dir) {
+		return loadJsons(Path.of(dir.toURI()));
+	}
+
+	/**
+	 * Used to get only values from the files in specified directory.
+	 * @param dir Path to the directory to load. Subdirectories will also be loaded.
+	 * @return ArrayList with JsonObjects parsed from found .json files.
+	 */
+	public static ArrayList<JsonObject> loadJsons(Path dir) {
+		return new ArrayList<>(loadJsonsWithPaths(dir).values());
+	}
+
+	/**
+	 * Used to get a map of Paths and values from the files in the specified directory.
+	 * @param dir Path to the directory to load. Subdirectories will also be loaded.
+	 * @return Map with Path -> JsonObject from the provided path.
+	 */
+	public static Map<Path, JsonObject> loadJsonsWithPaths(Path dir) {
+		Map<Path, JsonObject> results = new HashMap<>();
+		dir = dir.toAbsolutePath();
+		if (Files.notExists(dir) || !Files.isDirectory(dir)) {
+			EmendatusEnigmatica.LOGGER.error("Provided path to load jsons from (" + dir + ") doesn't exist.");
+			return results;
 		}
-		for (File file : files) {
-			if (file.isDirectory()) {
-				results.addAll(loadFilesAsJsonObjects(file));
-			} else if (file.getName().endsWith(".json")) {
-				JsonObject resultEntry;
-				FileReader reader = null;
+
+		try (Stream<Path> files = Files.list(dir)) {
+			files.forEach(file -> {
 				try {
-					JsonParser parser = new JsonParser();
-					reader = new FileReader(file);
-					resultEntry = parser.parse(reader).getAsJsonObject();
-					results.add(resultEntry);
+					if (Files.isDirectory(file)) {
+						results.putAll(loadJsonsWithPaths(file));
+						return;
+					}
+					if (file.getFileName().toString().endsWith(".json")) results.put(file, JsonParser.parseReader(Files.newBufferedReader(file)).getAsJsonObject());
 				} catch (Exception e) {
-					EmendatusEnigmatica.LOGGER.error("Failed to load configuration from " + dir + " in file " + file.getName());
-				} finally {
-					IOUtils.closeQuietly(reader);
+					EmendatusEnigmatica.LOGGER.error("Failed parsing json file at " +file.toAbsolutePath() + ".", e);
 				}
-			}
+			});
+		} catch (Exception ex) {
+			EmendatusEnigmatica.LOGGER.error("Failed opening provided path (" + dir + ") from which json files were meant to be loaded.", ex);
 		}
 		return results;
 	}


### PR DESCRIPTION
Hey there 😄
As talked on Discord, here is the PR with data validation for json files and feeback to the end user on what is missing / wrong in the data files. The PR as of writing this is still WIP (Missing Deposit validation), but I decided to put it up for now anyways for easier checks on the progress :D

UPDATE:
This also should resolve: #202 #211 

## Features
Validation of Data Json Files will stop EE from crashing the game by loading incorrect json files, or creating duplicates of ids etc.

Validation step will print to the log any errors and warnings found in the validation process, with file name present in each message, and additional message if file was marked as not acceptable to the registration.

![obraz](https://github.com/Ridanisaurus/EmendatusEnigmatica/assets/60540476/79a04a8c-c636-4911-a073-e69aa143699e)

## How does this even work?
Validation of jsons is done on the loading stage of the jsons, before they are passed to the MC Codec implementation. If validation fails, the json is not decoded to Java object and is not registred in EE registry.

Validators are stored in a map of String -> BiFunction in each json model class. If some model is a "sub-model" of another model, aka: Material has field with model of MaterialProperties, you can pass that map to the validator, and it will validate all fields of that object separetely.

All fields are stored in the Validator Map with key being a field name, and value a BiFunction used as a validator.

<hr>

If a field that doesn't exist in that map is found, a warning about unknown field will be printed.
![obraz](https://github.com/Ridanisaurus/EmendatusEnigmatica/assets/60540476/99c8057e-ff50-42f6-9be4-e847cc5d2141)

<hr>

If a required field is missing, a validation of the json will fail, and missing fields are going to be printed to the log.
![obraz](https://github.com/Ridanisaurus/EmendatusEnigmatica/assets/60540476/69df8fcf-4a50-408b-b2c6-6d3c761d3107)

### Validator class
Validator class is a "utility" class used to get basic validation BiFunctions, customized with name passed in the class constructor.
_**Name of the Validator has to be exactly the same as expected field to validate with use of newly created Validator!**_

It contains from simple "Field is required" to Validation of MC ResourceLocation syntax, Number Range and validation of other objects.

### Accessing data from other fields
Note: This was something I originally didn't plan on, and that was stupid decision :P So this system isn't perfect, but it does the job 😅

Accesssing data from the main object or the parent is done adding a suffix `_rg` -> Request Original, to the id in the Validators map of the model. BiFunction of Validator to validate obects will pass to the validator entire object instead of the field name of this validator.

<hr>

Accessing parent information (So, `Material.Properties.isBurnable` from `Material.Colors.gasColor` for example) requires passing the original object from the beginning to all validators of the `Colors` Model. Usage of `_rg` is required, but prohibited is the usage of `Validator#validateObject(JsonElement, Path, Map<...>)`, due to errors caused by missing fields in the parent object.

For passing parent object, required is use of `Validator#getPassParentToValidators(Map<String, BiFunction<JsonElement, Path, Boolean>>, boolean)` which passes the original object to the validators in additonal "TEMP" field.
This validator *does not* support arrays of arrays on any primite values. Can be used only when validated is meant to be Array of Objects or simply, Object.

It will launch validation as normal (aka validateObject without `_rg` suffix), and access to TEMP field can be gained with use of `_rg` suffix in the validators of the model that requires it.
Example can be seen in Material model.


## ToDo:
- [x] Universal Validation class (Validator)
<hr>

### Validation of Strata.
- [x] Validation of simple stuff
- [x] Check if stata with X ID already exists.
<hr>

- [x] Validation of Compat.
<hr>

### Validation of Material and it's sub-modules.
- [x] Validation of main model
- [x] Validation of sub-models.
- [x] Check if Material with X ID already exists.
<hr>

### Validation of Deposists and it's sub-modules.
- [x] Validation of the type
- [x] Validation of each sub-type
- [x] Validation of the objects
<hr>

### Code cleanup 😅
- [x] Remove checks for log, Logger was replaced with simple wrapper that removes any warning or error calls if logConfigErrors is set to fales in the config file.
- [x] Some general code cleanup
<hr>

- [x] Fix for #202
